### PR TITLE
Decode stun wire format

### DIFF
--- a/lib/jerboa.ex
+++ b/lib/jerboa.ex
@@ -2,7 +2,9 @@ defmodule Jerboa do
   @moduledoc """
   STUN/TURN encoder, decoder and client library
 
-  For the client utilities, see `Jerboa.Client`
+  For the client utilities, see `Jerboa.Client`.
+
+  For encoding and decoding of STUN format, head to `Jerboa.Format`.
   """
 
 end

--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -1,0 +1,6 @@
+defmodule Jerboa.Format do
+  @moduledoc """
+  Encoding and decoding of STUN messages
+  """
+  
+end

--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -2,5 +2,5 @@ defmodule Jerboa.Format do
   @moduledoc """
   Encoding and decoding of STUN messages
   """
-  
+
 end

--- a/lib/jerboa/format/stun.ex
+++ b/lib/jerboa/format/stun.ex
@@ -1,0 +1,27 @@
+defmodule Jerboa.Format.STUN do
+  @moduledoc """
+  Utility functions related to STUN messages
+  """
+
+  @type class :: :request
+               | :indication
+               | :success
+               | :error
+
+  @type integer_class :: 0 | 1 | 2 | 3
+
+  @doc """
+  Returns value of STUN magic cookie
+  """
+  @spec magic :: 554_869_826
+  def magic, do: 554_869_826
+
+  @doc """
+  Converts integer to atom representing STUN class
+  """
+  @spec class_from_integer(integer_class) :: class
+  def class_from_integer(0), do: :request
+  def class_from_integer(1), do: :indication
+  def class_from_integer(2), do: :success
+  def class_from_integer(3), do: :error
+end

--- a/lib/jerboa/format/stun/bare.ex
+++ b/lib/jerboa/format/stun/bare.ex
@@ -22,12 +22,12 @@ defmodule Jerboa.Format.STUN.Bare do
     with {:ok, header} <- validate_header_length(packet),
                    :ok <- validate_first_two_bits(header),
                    :ok <- validate_stun_magic(header),
-                  t_id <- extract_transaction_id(header),
-                  type <- extract_stun_type(header),
-                 class <- decode_message_class(type),
-                method <- extract_message_method(type),
      {:ok, body, rest} <- validate_body_length(packet),
           {:ok, attrs} <- extract_attributes(body) do
+      t_id   = extract_transaction_id(header)
+      type   = extract_stun_type(header)
+      class  = decode_message_class(type)
+      method = extract_message_method(type)
       struct = %__MODULE__{
         t_id: t_id,
         class: class,

--- a/lib/jerboa/format/stun/bare.ex
+++ b/lib/jerboa/format/stun/bare.ex
@@ -1,0 +1,70 @@
+defmodule Jerboa.Format.STUN.Bare do
+  @moduledoc false
+
+  alias Jerboa.Format.STUN
+
+  defstruct [:t_id, :class, :method, attrs: [], raw: <<>>]
+
+  @stun_magic STUN.magic
+
+  @type bare_attr :: {type :: binary, value :: binary}
+
+  @type t :: %__MODULE__{
+      t_id: non_neg_integer,
+     class: STUN.class,
+    method: non_neg_integer,
+     attrs: [bare_attr],
+       raw: binary
+  }
+
+  @spec decode(packet :: binary) :: {:ok, t} | {:error, reason :: term}
+  def decode(packet) do
+    with {:ok, header} <- validate_header_length(packet),
+                   :ok <- validate_first_two_bits(header),
+                   :ok <- validate_stun_magic(header),
+                  t_id <- extract_transaction_id(header),
+                  type <- extract_stun_type(header),
+                 class <- decode_message_class(type),
+                method <- extract_message_method(type) do
+      struct = %__MODULE__{
+        t_id: t_id,
+        class: class,
+        method: method,
+        raw: packet
+      }
+      {:ok, struct}
+    else
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp validate_header_length(<<header::20-binary, _rest::bitstring>>) do
+    {:ok, header}
+  end
+  defp validate_header_length(_), do: {:error, "Invalid header length"}
+
+  defp validate_first_two_bits(<<0::2, _rest::bitstring>>), do: :ok
+  defp validate_first_two_bits(_) do
+    {:error, "First two bits of STUN packet should be zeroed"}
+  end
+
+  defp validate_stun_magic(<<_::32, @stun_magic::32, _::binary>>), do: :ok
+  defp validate_stun_magic(_), do: {:error, "Invalid STUN magic cookie"}
+
+  defp extract_transaction_id(<<_::8-binary, t_id::96>>), do: t_id
+
+  defp extract_stun_type(<<_::2, type::14-bitstring, _rest::bitstring>>) do
+    type
+  end
+
+  defp decode_message_class(<<_::5, c1::1, _::3, c0::1, _::4>>) do
+    <<class::2>> = <<c1::1, c0::1>>
+    STUN.class_from_integer(class)
+  end
+
+  defp extract_message_method(<<m2::5, _::1, m1::3, _::1, m0::4>>) do
+    <<method::12>> = <<m2::5, m1::3, m0::4>>
+    method
+  end
+end

--- a/lib/jerboa/format/stun/bare.ex
+++ b/lib/jerboa/format/stun/bare.ex
@@ -77,12 +77,13 @@ defmodule Jerboa.Format.STUN.Bare do
   end
   defp validate_body_length(_), do: {:error, "Invalid message body length"}
 
+
   defp extract_attributes(body, acc \\ [])
   defp extract_attributes(<<>>, acc), do: {:ok, acc}
   defp extract_attributes(body, acc) do
     with {:ok, type, length, val_and_rest} <- extract_attr_type_and_length(body),
-                {:ok, value, pad_and_rest} <- extract_attr_value(length, val_and_rest),
-                               {:ok, rest} <- trim_padding(pad_and_rest, length) do
+         {:ok, value, pad_and_rest} <- extract_attr_value(length, val_and_rest),
+         {:ok, rest} <- trim_padding(pad_and_rest, length) do
       extract_attributes(rest, [{type, value} | acc])
     else
       {:error, _reason} = error ->

--- a/lib/jerboa/format/stun/bare.ex
+++ b/lib/jerboa/format/stun/bare.ex
@@ -17,7 +17,7 @@ defmodule Jerboa.Format.STUN.Bare do
        raw: binary
   }
 
-  @spec decode(packet :: binary) :: {:ok, t} | {:error, reason :: term}
+  @spec decode(packet :: binary) :: {:ok, t} | {:ok, t, binary} | {:error, reason :: term}
   def decode(packet) do
     with {:ok, header} <- validate_header_length(packet),
                    :ok <- validate_first_two_bits(header),
@@ -35,12 +35,15 @@ defmodule Jerboa.Format.STUN.Bare do
         attrs: Enum.reverse(attrs),
         raw: packet
       }
-      {:ok, struct}
+      maybe_return_rest(struct, rest)
     else
       {:error, _reason} = error ->
         error
     end
   end
+
+  defp maybe_return_rest(struct, <<>>), do: {:ok, struct}
+  defp maybe_return_rest(struct, rest), do: {:ok, struct, rest}
 
   defp validate_header_length(<<header::20-binary, _rest::bitstring>>) do
     {:ok, header}

--- a/lib/jerboa/format/stun/bare.ex
+++ b/lib/jerboa/format/stun/bare.ex
@@ -7,7 +7,7 @@ defmodule Jerboa.Format.STUN.Bare do
 
   @stun_magic STUN.magic
 
-  @type bare_attr :: {type :: binary, value :: binary}
+  @type bare_attr :: {type :: non_neg_integer, value :: binary}
 
   @type t :: %__MODULE__{
       t_id: non_neg_integer,
@@ -25,11 +25,14 @@ defmodule Jerboa.Format.STUN.Bare do
                   t_id <- extract_transaction_id(header),
                   type <- extract_stun_type(header),
                  class <- decode_message_class(type),
-                method <- extract_message_method(type) do
+                method <- extract_message_method(type),
+     {:ok, body, rest} <- validate_body_length(packet),
+          {:ok, attrs} <- extract_attributes(body) do
       struct = %__MODULE__{
         t_id: t_id,
         class: class,
         method: method,
+        attrs: Enum.reverse(attrs),
         raw: packet
       }
       {:ok, struct}
@@ -66,5 +69,57 @@ defmodule Jerboa.Format.STUN.Bare do
   defp extract_message_method(<<m2::5, _::1, m1::3, _::1, m0::4>>) do
     <<method::12>> = <<m2::5, m1::3, m0::4>>
     method
+  end
+
+  defp validate_body_length(<<_::16, length::16, _::128,
+                              body::size(length)-binary, rest::bitstring>>) do
+    {:ok, body, rest}
+  end
+  defp validate_body_length(_), do: {:error, "Invalid message body length"}
+
+  defp extract_attributes(body, acc \\ [])
+  defp extract_attributes(<<>>, acc), do: {:ok, acc}
+  defp extract_attributes(body, acc) do
+    with {:ok, type, length, val_and_rest} <- extract_attr_type_and_length(body),
+                {:ok, value, pad_and_rest} <- extract_attr_value(length, val_and_rest),
+                               {:ok, rest} <- trim_padding(pad_and_rest, length) do
+      extract_attributes(rest, [{type, value} | acc])
+    else
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp extract_attr_type_and_length(<<type::16, length::16, rest::binary>>) do
+    {:ok, type, length, rest}
+  end
+  defp extract_attr_type_and_length(_) do
+    {:error, "Not enough bytes for attribute"}
+  end
+
+  defp extract_attr_value(length, body) do
+    case body do
+      <<value::size(length)-binary, rest::binary>> ->
+        {:ok, value, rest}
+      _ ->
+        {:error, "Not enough bytes for attribute value"}
+    end
+  end
+
+  defp trim_padding(body, length) do
+    pad_len = calculate_padding(length)
+    case body do
+      <<_::size(pad_len)-binary, rest::binary>> ->
+        {:ok, rest}
+      _ ->
+        {:error, "No attribute padding"}
+    end
+  end
+
+  defp calculate_padding(length) do
+    case rem(length, 4) do
+      0 -> 0
+      n -> 4 - n
+    end
   end
 end

--- a/lib/jerboa/format/stun/bare.ex
+++ b/lib/jerboa/format/stun/bare.ex
@@ -19,9 +19,7 @@ defmodule Jerboa.Format.STUN.Bare do
 
   @spec decode(packet :: binary) :: {:ok, t} | {:ok, t, binary} | {:error, reason :: term}
   def decode(packet) do
-    with {:ok, header} <- validate_header_length(packet),
-                   :ok <- validate_first_two_bits(header),
-                   :ok <- validate_stun_magic(header),
+    with {:ok, header} <- validate_header(packet),
      {:ok, body, rest} <- validate_body_length(packet),
           {:ok, attrs} <- extract_attributes(body) do
       t_id   = extract_transaction_id(header)
@@ -44,6 +42,17 @@ defmodule Jerboa.Format.STUN.Bare do
 
   defp maybe_return_rest(struct, <<>>), do: {:ok, struct}
   defp maybe_return_rest(struct, rest), do: {:ok, struct, rest}
+
+  defp validate_header(packet) do
+    with {:ok, header} <- validate_header_length(packet),
+                   :ok <- validate_first_two_bits(header),
+                   :ok <- validate_stun_magic(header) do
+      {:ok, header}
+    else
+      {:error, _reason} = error ->
+        error
+    end
+  end
 
   defp validate_header_length(<<header::20-binary, _rest::bitstring>>) do
     {:ok, header}

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Jerboa.Mixfile do
      {:credo, "~> 0.5", runtime: false, only: [:dev, :test]},
      {:dialyxir, "~> 0.4", runtime: false, only: :dev},
      {:excoveralls, "~> 0.5", runtime: false, only: :test},
-     {:inch_ex, "~> 0.5", runtime: false, only: :dev}]
+     {:inch_ex, "~> 0.5", runtime: false, only: :dev},
+     {:quixir, "~> 0.9", runtime: false, only: :test}]
   end
 
   defp docs do

--- a/mix.lock
+++ b/mix.lock
@@ -13,4 +13,6 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "pollution": {:hex, :pollution, "0.9.0", "2d172aeedc444f0fc06a69b03bb6a560fb141bcafcc0c8189c29b10ee6e50893", [:mix], []},
+  "quixir": {:hex, :quixir, "0.9.1", "b9a45930f330ba485c1cb976afc9f5ceb14ebbe10faf755e0796bb971396c37c", [:mix], [{:pollution, "~> 0.9", [hex: :pollution, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}

--- a/test/jerboa/format/stun/bare_test.exs
+++ b/test/jerboa/format/stun/bare_test.exs
@@ -19,7 +19,8 @@ defmodule Jerboa.Format.STUN.BareTest do
         bit_length = length * 8 - 2
         packet = <<first_two::2, content::size(bit_length)>>
 
-        assert {:error, "First two bits of STUN packet should be zeroed"} = Bare.decode packet
+        error_msg = "First two bits of STUN packet should be zeroed"
+        assert {:error, ^error_msg} = Bare.decode packet
       end
     end
 
@@ -91,7 +92,8 @@ defmodule Jerboa.Format.STUN.BareTest do
                      attr_value::size(attr_length)-unit(8)>>
         packet = create_packet(type, t_id, bin_attr)
 
-        assert {:error, "Not enough bytes for attribute value"} = Bare.decode packet
+        error_msg = "Not enough bytes for attribute value"
+        assert {:error, ^error_msg} = Bare.decode packet
       end
     end
 
@@ -126,7 +128,8 @@ defmodule Jerboa.Format.STUN.BareTest do
   end
 
   defp encode_attributes(attrs) do
-    Enum.map(attrs, fn {type, value} ->
+    attrs
+    |> Enum.map(fn {type, value} ->
       length = byte_size(value)
       pad_len = calculate_padding(length)
       <<type::16, length::16, value::binary, 0::size(pad_len)-unit(8)>>

--- a/test/jerboa/format/stun/bare_test.exs
+++ b/test/jerboa/format/stun/bare_test.exs
@@ -1,0 +1,53 @@
+defmodule Jerboa.Format.STUN.BareTest do
+  use ExUnit.Case
+  use Quixir
+
+  alias Jerboa.Format.STUN.Bare
+
+  describe "decode/1" do
+    test "fails given packet with not enough bytes for header" do
+      ptest length: int(min: 0, max: 159), content: int(min: 0) do
+        packet = <<content::size(length)>>
+
+        assert {:error, _} = Bare.decode packet
+      end
+    end
+
+    test "fails given packet not starting with two zeroed bits" do
+      ptest first_two: int(min: 1, max: 3), content: int(min: 0),
+            length: int(min: 20) do
+        bit_length = length * 8 - 2
+        packet = <<first_two::2, content::size(bit_length)>>
+
+        assert {:error, _} = Bare.decode packet
+      end
+    end
+
+    test "fails given packet with invalid STUN magic cookie" do
+      ptest before_magic: int(min: 0), magic: int(min: 0),
+            after_magic: int(min: 0), length: int(min: 12) do
+        packet = <<0::2, before_magic::30, magic::32,
+                   after_magic::unit(8)-size(length)>>
+
+        assert {:error, _} = Bare.decode packet
+      end
+    end
+
+    test "extracts method and decodes class from the packet" do
+      ptest method: int(min: 0), class: int(min: 0, max: 3), t_id: int(min: 0),
+            length: int(min: 0), body: int(min: 0) do
+        <<c1::1, c0::1>> = <<class::2>>
+        <<m2::5, m1::3, m0::4>> = <<method::12>>
+        magic = Jerboa.Format.STUN.magic
+        packet = <<0::2, m2::5, c1::1, m1::3, c0::1, m0::4, length::16,
+                   magic::32, t_id::96, body::size(length)-unit(8)>>
+
+        {:ok, bare} = Bare.decode packet
+        decoded_class = Jerboa.Format.STUN.class_from_integer(class)
+
+        assert method == bare.method
+        assert decoded_class == bare.class
+      end
+    end
+  end
+end

--- a/test/jerboa/format/stun/bare_test.exs
+++ b/test/jerboa/format/stun/bare_test.exs
@@ -1,5 +1,5 @@
 defmodule Jerboa.Format.STUN.BareTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use Quixir
 
   alias Jerboa.Format.STUN.Bare
@@ -34,13 +34,13 @@ defmodule Jerboa.Format.STUN.BareTest do
     end
 
     test "extracts method and decodes class from the packet" do
-      ptest method: int(min: 0), class: int(min: 0, max: 3), t_id: int(min: 0),
-            length: int(min: 0), body: int(min: 0) do
+      ptest method: int(min: 0), class: int(min: 0, max: 3),
+            t_id: int(min: 0) do
         <<c1::1, c0::1>> = <<class::2>>
         <<m2::5, m1::3, m0::4>> = <<method::12>>
         magic = Jerboa.Format.STUN.magic
-        packet = <<0::2, m2::5, c1::1, m1::3, c0::1, m0::4, length::16,
-                   magic::32, t_id::96, body::size(length)-unit(8)>>
+        packet = <<0::2, m2::5, c1::1, m1::3, c0::1, m0::4, 0::16,
+                   magic::32, t_id::96>>
 
         {:ok, bare} = Bare.decode packet
         decoded_class = Jerboa.Format.STUN.class_from_integer(class)
@@ -49,5 +49,88 @@ defmodule Jerboa.Format.STUN.BareTest do
         assert decoded_class == bare.class
       end
     end
+
+    test "fails given packet with too short message body" do
+      ptest type: int(min: 0), t_id: int(min: 0), length: int(min: 1000),
+            body: int(min: 0), body_length: int(min: 0, max: ^length - 1) do
+        magic = Jerboa.Format.STUN.magic
+        packet = <<0::2, type::14, length::16, magic::32, t_id::96,
+                   body::unit(8)-size(body_length)>>
+
+        assert {:error, _} = Bare.decode packet
+      end
+    end
+
+    test "extracts attributes from message body" do
+      ptest type: int(min: 0), t_id: int(min: 0),
+            attrs: list(of: tuple(like: {int(min: 0), string()})) do
+        bin_attrs = encode_attributes(attrs)
+        packet = create_packet(type, t_id, bin_attrs)
+
+        {:ok, bare} = Bare.decode packet
+
+        assert attrs == bare.attrs
+      end
+    end
+
+    test "fails if body does not have enough bytes for attribute" do
+      ptest type: int(min: 0), t_id: int(min: 0), extra: int(min: 1, max: 3),
+            attrs: list(of: tuple(like: {int(min: 0), string()})) do
+        bin_attrs = encode_attributes(attrs)
+        bin_attrs = <<bin_attrs::binary, 1::size(extra)-unit(8)>>
+        packet = create_packet(type, t_id, bin_attrs)
+
+        assert {:error, _} = Bare.decode packet
+      end
+    end
+
+    test "fails if there are not enough bytes for attribute value" do
+      ptest type: int(min: 0), t_id: int(min: 0), attr_length: int(min: 0),
+            attr_type: int(min: 0), attr_value: int() do
+        bin_attr = <<attr_type::16, (attr_length + 1)::16,
+                     attr_value::size(attr_length)-unit(8)>>
+        packet = create_packet(type, t_id, bin_attr)
+
+        assert {:error, _} = Bare.decode packet
+      end
+    end
+
+    test "fails if there is no attribute padding" do
+      ptest type: int(min: 0), t_id: int(min: 0), attr_type: int(min: 0),
+            attr_value: int(), attr_length: int(min: 0) do
+        attr_length =
+          if rem(attr_length, 4) == 0, do: attr_length + 1, else: attr_length
+        bin_attr = <<attr_type::16, attr_length::16,
+                     attr_value::size(attr_length)-unit(8)>>
+        packet = create_packet(type, t_id, bin_attr)
+
+        assert {:error, _} = Bare.decode packet
+      end
+    end
+  end
+
+  ## Test helpers
+
+  defp calculate_padding(length) do
+    case rem(length, 4) do
+      0 -> 0
+      n -> 4 - n
+    end
+  end
+
+  defp create_packet(type, t_id, body) do
+    length = byte_size(body)
+    magic = Jerboa.Format.STUN.magic
+    header = <<0::2, type::14, length::16, magic::32, t_id::96>>
+    <<header::binary, body::binary>>
+  end
+
+  defp encode_attributes(attrs) do
+    Enum.map(attrs, fn {type, value} ->
+      length = byte_size(value)
+      pad_len = calculate_padding(length)
+      <<type::16, length::16, value::binary, 0::size(pad_len)-unit(8)>>
+    end)
+    |> Enum.join()
   end
 end

--- a/test/jerboa/format/stun/bare_test.exs
+++ b/test/jerboa/format/stun/bare_test.exs
@@ -9,7 +9,7 @@ defmodule Jerboa.Format.STUN.BareTest do
       ptest length: int(min: 0, max: 159), content: int(min: 0) do
         packet = <<content::size(length)>>
 
-        assert {:error, _} = Bare.decode packet
+        assert {:error, "Invalid header length"} = Bare.decode packet
       end
     end
 
@@ -19,7 +19,7 @@ defmodule Jerboa.Format.STUN.BareTest do
         bit_length = length * 8 - 2
         packet = <<first_two::2, content::size(bit_length)>>
 
-        assert {:error, _} = Bare.decode packet
+        assert {:error, "First two bits of STUN packet should be zeroed"} = Bare.decode packet
       end
     end
 
@@ -29,7 +29,7 @@ defmodule Jerboa.Format.STUN.BareTest do
         packet = <<0::2, before_magic::30, magic::32,
                    after_magic::unit(8)-size(length)>>
 
-        assert {:error, _} = Bare.decode packet
+        assert {:error, "Invalid STUN magic cookie"} = Bare.decode packet
       end
     end
 
@@ -57,7 +57,7 @@ defmodule Jerboa.Format.STUN.BareTest do
         packet = <<0::2, type::14, length::16, magic::32, t_id::96,
                    body::unit(8)-size(body_length)>>
 
-        assert {:error, _} = Bare.decode packet
+        assert {:error, "Invalid message body length"} = Bare.decode packet
       end
     end
 
@@ -80,7 +80,7 @@ defmodule Jerboa.Format.STUN.BareTest do
         bin_attrs = <<bin_attrs::binary, 1::size(extra)-unit(8)>>
         packet = create_packet(type, t_id, bin_attrs)
 
-        assert {:error, _} = Bare.decode packet
+        assert {:error, "Not enough bytes for attribute"} = Bare.decode packet
       end
     end
 
@@ -91,7 +91,7 @@ defmodule Jerboa.Format.STUN.BareTest do
                      attr_value::size(attr_length)-unit(8)>>
         packet = create_packet(type, t_id, bin_attr)
 
-        assert {:error, _} = Bare.decode packet
+        assert {:error, "Not enough bytes for attribute value"} = Bare.decode packet
       end
     end
 
@@ -104,7 +104,7 @@ defmodule Jerboa.Format.STUN.BareTest do
                      attr_value::size(attr_length)-unit(8)>>
         packet = create_packet(type, t_id, bin_attr)
 
-        assert {:error, _} = Bare.decode packet
+        assert {:error, "No attribute padding"} = Bare.decode packet
       end
     end
   end

--- a/test/jerboa/format/stun/bare_test.exs
+++ b/test/jerboa/format/stun/bare_test.exs
@@ -111,6 +111,15 @@ defmodule Jerboa.Format.STUN.BareTest do
     end
   end
 
+  test "returns rest if given binary is too long" do
+    ptest type: int(min: 0), t_id: int(min: 0), extra: string(min: 1) do
+      packet = create_packet(type, t_id, <<>>)
+      packet = <<packet::binary, extra::binary>>
+
+      assert {:ok, _, ^extra} = Bare.decode packet
+    end
+  end
+
   ## Test helpers
 
   defp calculate_padding(length) do


### PR DESCRIPTION
Proposed changes:
* decoding of STUN binary format into `Jerboa.Format.STUN.Bare` struct - this structure will be further validated on the next step of decoding
* tests for the decoder