### PR TITLE
Encode stun wire format

### DIFF
--- a/lib/jerboa/format/stun.ex
+++ b/lib/jerboa/format/stun.ex
@@ -3,6 +3,13 @@ defmodule Jerboa.Format.STUN do
   Utility functions related to STUN messages
   """
 
+  @typedoc """
+  Represents class of STUN message
+
+  Note that `:error` here refers to STUN
+  error response class, it is not an indication
+  that this value is invalid.
+  """
   @type class :: :request
                | :indication
                | :success
@@ -18,6 +25,13 @@ defmodule Jerboa.Format.STUN do
 
   @doc """
   Converts integer to atom representing STUN class
+
+  ## Examples
+
+      iex> Jerboa.Format.STUN.class_from_integer(0)
+      :request
+      iex> Jerboa.Format.STUN.class_from_integer(3)
+      :error # this is a valid STUN class
   """
   @spec class_from_integer(integer_class) :: class
   def class_from_integer(0), do: :request
@@ -27,6 +41,13 @@ defmodule Jerboa.Format.STUN do
 
   @doc """
   Converts atom to integer representing STUN class
+
+  ## Examples
+
+      iex> Jerboa.Format.STUN.class_to_integer(:indication)
+      1
+      iex> Jerboa.Format.STUN.class_to_integer(:success)
+      2
   """
   @spec class_to_integer(class) :: integer_class
   def class_to_integer(:request), do: 0

--- a/lib/jerboa/format/stun.ex
+++ b/lib/jerboa/format/stun.ex
@@ -24,4 +24,14 @@ defmodule Jerboa.Format.STUN do
   def class_from_integer(1), do: :indication
   def class_from_integer(2), do: :success
   def class_from_integer(3), do: :error
+
+  @doc """
+  Converts atom to integer representing STUN class
+  """
+  @spec class_to_integer(class) :: integer_class
+  def class_to_integer(:request), do: 0
+  def class_to_integer(:indication), do: 1
+  def class_to_integer(:success), do: 2
+  def class_to_integer(:error), do: 3
+
 end

--- a/test/jerboa/format/stun_test.exs
+++ b/test/jerboa/format/stun_test.exs
@@ -1,0 +1,4 @@
+defmodule Jerboa.Format.STUNTest do
+  use ExUnit.Case
+  doctest Jerboa.Format.STUN
+end

--- a/test/jerboa_test.exs
+++ b/test/jerboa_test.exs
@@ -1,4 +1,3 @@
 defmodule JerboaTest do
   use ExUnit.Case
-
 end


### PR DESCRIPTION
Proposed changes:
* encoder of `Jerboa.Format.STUN.Bare` struct to STUN binary format
* tests for the encoder