### PR TITLE
Struct containing decoding errors

### DIFF
--- a/lib/jerboa/format/stun/bare.ex
+++ b/lib/jerboa/format/stun/bare.ex
@@ -2,6 +2,7 @@ defmodule Jerboa.Format.STUN.Bare do
   @moduledoc false
 
   alias Jerboa.Format.STUN
+  alias STUN.DecodeError
 
   defstruct [:t_id, :class, :method, attrs: [], raw: <<>>]
 
@@ -17,7 +18,7 @@ defmodule Jerboa.Format.STUN.Bare do
        raw: binary
   }
 
-  @spec decode(packet :: binary) :: {:ok, t} | {:ok, t, binary} | {:error, reason :: term}
+  @spec decode(packet :: binary) :: {:ok, t} | {:ok, t, binary} | {:error, DecodeError.t}
   def decode(packet) do
     with {:ok, header} <- validate_header(packet),
      {:ok, body, rest} <- validate_body_length(packet),
@@ -35,8 +36,8 @@ defmodule Jerboa.Format.STUN.Bare do
       }
       maybe_return_rest(struct, rest)
     else
-      {:error, _reason} = error ->
-        error
+      {:error, reason} ->
+        {:error, %DecodeError{format: reason}}
     end
   end
 

--- a/lib/jerboa/format/stun/decode_error.ex
+++ b/lib/jerboa/format/stun/decode_error.ex
@@ -1,0 +1,17 @@
+defmodule Jerboa.Format.STUN.DecodeError do
+  @moduledoc """
+  Data structure containing information about decoding failure
+  """
+
+  defstruct [format: ""]
+
+  @typedoc """
+  `DecodeError` struct
+
+  * `format` - errors of STUN binary format, such as invalid cookie,
+    invalid packet length etc.
+  """
+  @type t :: %__MODULE__{
+    format: String.t
+  }
+end


### PR DESCRIPTION
Errors may happen on different stages of decoding process. It is convenient to have a single source of truth about these errors. `%DecodeErrors{}` struct can be extended once we add new parts of decoder.