### PR TITLE
Encoding + Decoding on the Server-side for the STUN Binding Method

### DIFF
--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -50,7 +50,9 @@ defmodule Jerboa.Format do
   """
   def encode(params) do
     params
+    |> Body.encode
     |> Header.encode
+    |> concatenate
   end
 
   @spec decode!(binary) :: t | no_return
@@ -89,5 +91,9 @@ defmodule Jerboa.Format do
       {:error, _} = e ->
         e
     end
+  end
+
+  defp concatenate(%__MODULE__{header: x, body: y}) do
+    x <> y
   end
 end

--- a/lib/jerboa/format/body.ex
+++ b/lib/jerboa/format/body.ex
@@ -3,6 +3,10 @@ defmodule Jerboa.Format.Body do
 
   alias Jerboa.Format.Body.Attribute
 
+  def encode(params = %Jerboa.Format{attributes: a}) do
+    encode(params, a)
+  end
+
   def decode(params = %Jerboa.Format{length: 0, body: <<>>}), do: {:ok, params}
   def decode(params = %Jerboa.Format{body: body}) do
     case decode(params, body, []) do
@@ -11,6 +15,13 @@ defmodule Jerboa.Format.Body do
       {:error, _} = e ->
         e
     end
+  end
+
+  defp encode(_, []) do
+    <<>>
+  end
+  defp encode(params, [attr|rest]) do
+    Attribute.encode(params, attr) <> encode(params, rest)
   end
 
   defp decode(params, <<t::16, s::16, c::bytes-size(s), r::binary>>, attrs) do

--- a/lib/jerboa/format/body.ex
+++ b/lib/jerboa/format/body.ex
@@ -4,7 +4,7 @@ defmodule Jerboa.Format.Body do
   alias Jerboa.Format.Body.Attribute
 
   def encode(params = %Jerboa.Format{attributes: a}) do
-    encode(params, a)
+    %{params | body: encode(params, a)}
   end
 
   def decode(params = %Jerboa.Format{length: 0, body: <<>>}), do: {:ok, params}

--- a/lib/jerboa/format/body/attribute.ex
+++ b/lib/jerboa/format/body/attribute.ex
@@ -15,6 +15,12 @@ defmodule Jerboa.Format.Body.Attribute do
   }
 
   @doc false
+  @spec encode(Jerboa.Format.t, struct) :: binary
+  def encode(p, a = %Attribute.XORMappedAddress{}) do
+    encode_(0x0020, Attribute.XORMappedAddress.encode(p, a))
+  end
+
+  @doc false
   @spec decode(params :: Jerboa.Format.t, type :: non_neg_integer, value :: binary)
     :: {:ok, t} | {:error, struct} | :ignore
   def decode(params, 0x0020, v) do
@@ -25,5 +31,9 @@ defmodule Jerboa.Format.Body.Attribute do
   end
   def decode(_, _, _) do
     :ignore
+  end
+
+  defp encode_(type, value) do
+    <<type::16, byte_size(value)::16, value::binary>>
   end
 end

--- a/lib/jerboa/format/body/attribute.ex
+++ b/lib/jerboa/format/body/attribute.ex
@@ -5,6 +5,8 @@ defmodule Jerboa.Format.Body.Attribute do
   alias Jerboa.Format.Body.Attribute
   alias Jerboa.Format.ComprehensionError
 
+  @biggest_16 65_535
+
   defstruct [:name, :value]
   @typedoc """
   The data structure representing a STUN attribute
@@ -34,6 +36,10 @@ defmodule Jerboa.Format.Body.Attribute do
   end
 
   defp encode_(type, value) do
-    <<type::16, byte_size(value)::16, value::binary>>
+    encode(type, byte_size(value), value)
+  end
+
+  defp encode(type, length, value) when length < @biggest_16 do
+    <<type::16, length::16, value::binary>>
   end
 end

--- a/lib/jerboa/format/body/attribute/xor_mapped_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_mapped_address.ex
@@ -35,13 +35,10 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddress do
   @spec decode(params :: Jerboa.Format.t, value :: binary) :: {:ok, Attribute.t}
                                                             | {:error, struct}
   def decode(_, <<_::8, @ip_4, p::16, a::32-bits>>) do
-    {:ok, %Attribute{name: __MODULE__,
-                     value: %__MODULE__{family: :ipv4, address: ip_4_decode(a), port: port(p)}}}
+    {:ok, %Attribute{name: __MODULE__, value: attribute(a, p)}}
   end
   def decode(%Jerboa.Format{identifier: i}, <<_::8, @ip_6, p::16, a::128-bits>>) do
-    {:ok, %Attribute{name: __MODULE__,
-                     value: %__MODULE__{family: :ipv6, address: ip_6_decode(a, i),
-                                        port: port(p)}}}
+    {:ok, %Attribute{name: __MODULE__, value: attribute(a, p, i)}}
   end
   def decode(_, value) when byte_size(value) != 20 and byte_size(value) != 8 do
     {:error, LengthError.exception(length: byte_size(value))}
@@ -55,6 +52,22 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddress do
 
   defp encode(f, a, p) do
     <<0::8, f::8-bits, port(p)::16, a::binary>>
+  end
+
+  defp attribute(a, p) do
+    %__MODULE__{
+      family: :ipv4,
+      address: ip_4_decode(a),
+      port: port(p)
+    }
+  end
+
+  defp attribute(a, p, i) do
+    %__MODULE__{
+      family: :ipv6,
+      address: ip_6_decode(a, i),
+      port: port(p)
+    }
   end
 
   defp port(x) do

--- a/lib/jerboa/format/body/attribute/xor_mapped_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_mapped_address.ex
@@ -23,11 +23,11 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddress do
   }
 
   @doc false
-  @spec encode(Jerboa.Format.t) :: binary
-  def encode(%Jerboa.Format{attributes: [%__MODULE__{family: :ipv4, address: a, port: p}]}) do
+  @spec encode(Jerboa.Format.t, t) :: binary
+  def encode(_, %__MODULE__{family: :ipv4, address: a, port: p}) do
     encode(@ip_4, ip_4_encode(a), p)
   end
-  def encode(%Jerboa.Format{attributes: [%__MODULE__{family: :ipv6, address: a, port: p}], identifier: i}) do
+  def encode(%Jerboa.Format{identifier: i}, %__MODULE__{family: :ipv6, address: a, port: p}) do
     encode(@ip_6, ip_6_encode(a, i), p)
   end
 

--- a/lib/jerboa/format/header.ex
+++ b/lib/jerboa/format/header.ex
@@ -9,7 +9,7 @@ defmodule Jerboa.Format.Header do
     t = Type.encode(params)
     l = Length.encode(params)
     i = Identifier.encode(params)
-    encode t, l, i
+    %{params | header: encode(t, l, i)}
   end
 
   def decode(x = %Jerboa.Format{header: <<0::2, t::14-bits, l::16-bits, @magic_cookie::bytes, i::96-bits>>}) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Jerboa.Mixfile do
      version: "0.1.0",
      description: "STUN/TURN encoder, decoder and client library",
      elixir: "~> 1.4",
+     elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),
@@ -19,6 +20,9 @@ defmodule Jerboa.Mixfile do
     [extra_applications: [:logger],
      mod: {Jerboa.Client.Application, []}]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/helper"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   defp deps do
     [{:ex_doc, "~> 0.14", runtime: false, only: :dev},

--- a/test/helper/attribute.ex
+++ b/test/helper/attribute.ex
@@ -1,0 +1,7 @@
+defmodule Jerboa.Test.Helper.Attribute do
+  @moduledoc false
+
+  def total(x) do
+    x |> Keyword.values |> Enum.sum
+  end
+end

--- a/test/helper/xor_mapped_address.ex
+++ b/test/helper/xor_mapped_address.ex
@@ -1,0 +1,28 @@
+defmodule Jerboa.Test.Helper.XORMappedAddress do
+  alias Jerboa.Format.Body.Attribute.XORMappedAddress
+
+  def struct(4) do
+    struct(:ipv4, ip_4_a(), port())
+  end
+  def struct(6) do
+    struct(:ipv6, ip_6_a(), port())
+  end
+
+  def ip_4_a do
+    {0, 0, 0, 0}
+  end
+
+  def ip_6_a do
+    :erlang.make_tuple(16, 0)
+  end
+
+  def port, do: 0
+
+  def i do
+    :crypto.strong_rand_bytes(div(96, 8))
+  end
+
+  defp struct(f, a, p) do
+    %XORMappedAddress{family: f, address: a, port: p}
+  end
+end

--- a/test/helper/xor_mapped_address.ex
+++ b/test/helper/xor_mapped_address.ex
@@ -1,4 +1,6 @@
 defmodule Jerboa.Test.Helper.XORMappedAddress do
+  @moduledoc false
+
   alias Jerboa.Format.Body.Attribute.XORMappedAddress
 
   def struct(4) do

--- a/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
+++ b/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
@@ -92,9 +92,8 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddressTest do
       a = {0, 0, 0, 0}
       p = 0
       attr = %XORMappedAddress{family: f, address: a, port: p}
-      params = %Jerboa.Format{attributes: [attr]}
 
-      b = XORMappedAddress.encode(params)
+      b = XORMappedAddress.encode(%Jerboa.Format{}, attr)
 
       assert b == <<padding()::8, ip_4()::8, x_port(p)::16-bits, x_ip4_addr(a)::32-bits>>
     end
@@ -105,9 +104,9 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddressTest do
       p = 0
       i = :crypto.strong_rand_bytes(div(96, 8))
       attr = %XORMappedAddress{family: f, address: a, port: p}
-      params = %Jerboa.Format{attributes: [attr], identifier: i}
+      params = %Jerboa.Format{identifier: i}
 
-      b = XORMappedAddress.encode(params)
+      b = XORMappedAddress.encode(params, attr)
 
       assert b == <<padding()::8, ip_6()::8, x_port(p)::16-bits, x_ip6_addr(a, i)::128-bits>>
     end

--- a/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
+++ b/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
@@ -85,6 +85,20 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddressTest do
     end
   end
 
+  describe "XORMappedAddress.encode/1" do
+
+    test "IPv4" do
+      a = {0, 0, 0, 0}
+      p = 0
+      attr = %XORMappedAddress{family: :ipv4, address: a, port: p}
+      params = %Jerboa.Format{attributes: [attr]}
+
+      b = XORMappedAddress.encode(params)
+
+      assert b == <<padding()::8, ip_4()::8, x_port(p)::16-bits, x_ip4_addr(a)::32-bits>>
+    end
+  end
+
   defp padding, do: 0
 
   defp ip_4, do: 0x01

--- a/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
+++ b/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
@@ -88,14 +88,28 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddressTest do
   describe "XORMappedAddress.encode/1" do
 
     test "IPv4" do
+      f = :ipv4
       a = {0, 0, 0, 0}
       p = 0
-      attr = %XORMappedAddress{family: :ipv4, address: a, port: p}
+      attr = %XORMappedAddress{family: f, address: a, port: p}
       params = %Jerboa.Format{attributes: [attr]}
 
       b = XORMappedAddress.encode(params)
 
       assert b == <<padding()::8, ip_4()::8, x_port(p)::16-bits, x_ip4_addr(a)::32-bits>>
+    end
+
+    test "IPv6" do
+      f =  :ipv6
+      a = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0}
+      p = 0
+      i = :crypto.strong_rand_bytes(div(96, 8))
+      attr = %XORMappedAddress{family: f, address: a, port: p}
+      params = %Jerboa.Format{attributes: [attr], identifier: i}
+
+      b = XORMappedAddress.encode(params)
+
+      assert b == <<padding()::8, ip_6()::8, x_port(p)::16-bits, x_ip6_addr(a, i)::128-bits>>
     end
   end
 

--- a/test/jerboa/format/body/attribute_test.exs
+++ b/test/jerboa/format/body/attribute_test.exs
@@ -13,16 +13,23 @@ defmodule Jerboa.Format.Body.AttributeTest do
 
       bin = Attribute.encode %Format{}, attr
 
-      assert <<0x0020::16, 8::16, _::64>> = bin
+      assert type(bin) === 0x0020
+      assert length_(bin) === 32 + 32
     end
 
     test "IPv6 XORMappedAddress as a TLV" do
+      i = XORMAHelper.i()
       attr = XORMAHelper.struct(6)
-      params = %Format{identifier: XORMAHelper.i()}
+      params = %Format{identifier: i}
 
       bin = Attribute.encode params, attr
 
-      assert <<0x0020::16, 20::16, _::160>> = bin
+      assert type(bin) === 0x0020
+      assert length_(bin) === 32 + 128
     end
   end
+
+  defp type(<<x::16, _::binary>>), do: x
+
+  defp length_(<<_::16, x::16, _::size(x)-bytes>>), do: 8 * x
 end

--- a/test/jerboa/format/body/attribute_test.exs
+++ b/test/jerboa/format/body/attribute_test.exs
@@ -1,6 +1,8 @@
 defmodule Jerboa.Format.Body.AttributeTest do
   use ExUnit.Case, async: true
+
   alias Jerboa.Test.Helper.XORMappedAddress, as: XORMAHelper
+
   alias Jerboa.Format
   alias Jerboa.Format.Body.Attribute
 

--- a/test/jerboa/format/body/attribute_test.exs
+++ b/test/jerboa/format/body/attribute_test.exs
@@ -2,6 +2,7 @@ defmodule Jerboa.Format.Body.AttributeTest do
   use ExUnit.Case, async: true
 
   alias Jerboa.Test.Helper.XORMappedAddress, as: XORMAHelper
+  alias Jerboa.Test.Helper.Attribute, as: AHelper
 
   alias Jerboa.Format
   alias Jerboa.Format.Body.Attribute
@@ -14,7 +15,7 @@ defmodule Jerboa.Format.Body.AttributeTest do
       bin = Attribute.encode %Format{}, attr
 
       assert type(bin) === 0x0020
-      assert length_(bin) === 32 + 32
+      assert length_(bin) === AHelper.total(address: 32, other: 32)
     end
 
     test "IPv6 XORMappedAddress as a TLV" do
@@ -25,7 +26,7 @@ defmodule Jerboa.Format.Body.AttributeTest do
       bin = Attribute.encode params, attr
 
       assert type(bin) === 0x0020
-      assert length_(bin) === 32 + 128
+      assert length_(bin) === AHelper.total(address: 128, other: 32)
     end
   end
 

--- a/test/jerboa/format/body/attribute_test.exs
+++ b/test/jerboa/format/body/attribute_test.exs
@@ -1,15 +1,13 @@
 defmodule Jerboa.Format.Body.AttributeTest do
   use ExUnit.Case, async: true
+  alias Jerboa.Test.Helper.XORMappedAddress, as: XORMAHelper
   alias Jerboa.Format
   alias Jerboa.Format.Body.Attribute
 
   describe "Attribute.encode/2" do
 
     test "IPv4 XORMappedAddress as a TLV" do
-      f = :ipv4
-      a = {0, 0, 0, 0}
-      p = 0
-      attr = %Attribute.XORMappedAddress{family: f, address: a, port: p}
+      attr = XORMAHelper.struct(4)
 
       bin = Attribute.encode %Format{}, attr
 
@@ -17,12 +15,8 @@ defmodule Jerboa.Format.Body.AttributeTest do
     end
 
     test "IPv6 XORMappedAddress as a TLV" do
-      f = :ipv6
-      a = {0,0,0,0 ,0,0,0,0, 0,0,0,0, 0,0,0,0}
-      p = 0
-      i = :crypto.strong_rand_bytes(div(96, 8))
-      attr = %Attribute.XORMappedAddress{family: f, address: a, port: p}
-      params = %Format{identifier: i}
+      attr = XORMAHelper.struct(6)
+      params = %Format{identifier: XORMAHelper.i()}
 
       bin = Attribute.encode params, attr
 

--- a/test/jerboa/format/body/attribute_test.exs
+++ b/test/jerboa/format/body/attribute_test.exs
@@ -1,0 +1,32 @@
+defmodule Jerboa.Format.Body.AttributeTest do
+  use ExUnit.Case, async: true
+  alias Jerboa.Format
+  alias Jerboa.Format.Body.Attribute
+
+  describe "Attribute.encode/2" do
+
+    test "IPv4 XORMappedAddress as a TLV" do
+      f = :ipv4
+      a = {0, 0, 0, 0}
+      p = 0
+      attr = %Attribute.XORMappedAddress{family: f, address: a, port: p}
+
+      bin = Attribute.encode %Format{}, attr
+
+      assert <<0x0020::16, 8::16, _::64>> = bin
+    end
+
+    test "IPv6 XORMappedAddress as a TLV" do
+      f = :ipv6
+      a = {0,0,0,0 ,0,0,0,0, 0,0,0,0, 0,0,0,0}
+      p = 0
+      i = :crypto.strong_rand_bytes(div(96, 8))
+      attr = %Attribute.XORMappedAddress{family: f, address: a, port: p}
+      params = %Format{identifier: i}
+
+      bin = Attribute.encode params, attr
+
+      assert <<0x0020::16, 20::16, _::160>> = bin
+    end
+  end
+end

--- a/test/jerboa/format/body_test.exs
+++ b/test/jerboa/format/body_test.exs
@@ -1,7 +1,21 @@
 defmodule Jerboa.Format.BodyTest do
   use ExUnit.Case, async: true
+
+  alias Jerboa.Test.Helper.XORMappedAddress, as: XORMAHelper
+
   alias Jerboa.Format
   alias Jerboa.Format.Body
+
+  describe "Body.encode/2" do
+
+    test "one (XORMappedAddress) attribute into one TLV field" do
+      attr = XORMAHelper.struct(4)
+
+      bin = Body.encode %Format{attributes: [attr]}
+
+      assert <<_::16, 8::16, _::64>> = bin
+    end
+  end
 
   describe "Body.decode/1" do
 

--- a/test/jerboa/format/body_test.exs
+++ b/test/jerboa/format/body_test.exs
@@ -2,6 +2,7 @@ defmodule Jerboa.Format.BodyTest do
   use ExUnit.Case, async: true
 
   alias Jerboa.Test.Helper.XORMappedAddress, as: XORMAHelper
+  alias Jerboa.Test.Helper.Attribute, as: AHelper
 
   alias Jerboa.Format
   alias Jerboa.Format.Body
@@ -13,7 +14,7 @@ defmodule Jerboa.Format.BodyTest do
 
       %Format{body: bin} = Body.encode %Format{attributes: [attr]}
 
-      assert bit_size(bin) === total(type: 16, length: 16, value: 64)
+      assert bit_size(bin) === AHelper.total(type: 16, length: 16, value: 64)
     end
   end
 
@@ -42,9 +43,5 @@ defmodule Jerboa.Format.BodyTest do
 
   defp known_comprehension_optional do
     []
-  end
-
-  defp total(x) do
-    x |> Keyword.values |> Enum.sum
   end
 end

--- a/test/jerboa/format/body_test.exs
+++ b/test/jerboa/format/body_test.exs
@@ -13,7 +13,7 @@ defmodule Jerboa.Format.BodyTest do
 
       %Format{body: bin} = Body.encode %Format{attributes: [attr]}
 
-      assert <<_::16, 8::16, _::64>> = bin
+      assert bit_size(bin) === total(type: 16, length: 16, value: 64)
     end
   end
 
@@ -42,5 +42,9 @@ defmodule Jerboa.Format.BodyTest do
 
   defp known_comprehension_optional do
     []
+  end
+
+  defp total(x) do
+    x |> Keyword.values |> Enum.sum
   end
 end

--- a/test/jerboa/format/body_test.exs
+++ b/test/jerboa/format/body_test.exs
@@ -11,7 +11,7 @@ defmodule Jerboa.Format.BodyTest do
     test "one (XORMappedAddress) attribute into one TLV field" do
       attr = XORMAHelper.struct(4)
 
-      bin = Body.encode %Format{attributes: [attr]}
+      %Format{body: bin} = Body.encode %Format{attributes: [attr]}
 
       assert <<_::16, 8::16, _::64>> = bin
     end

--- a/test/jerboa/format/head_test.exs
+++ b/test/jerboa/format/head_test.exs
@@ -48,5 +48,16 @@ defmodule Jerboa.Format.HeaderTest do
       assert 16 === bit_size x
       assert <<0, 4>> = x
     end
+
+    test "binding success response" do
+      assert <<2::6, 1>> == Header.Type.encode(%Jerboa.Format{class: :success, method: :binding})
+    end
+  end
+
+  describe "Header.*.decode/1" do
+
+    test "binding request" do
+      assert {:ok, :request, :binding} == Header.Type.decode <<0::6, 1>>
+    end
   end
 end

--- a/test/jerboa/format/head_test.exs
+++ b/test/jerboa/format/head_test.exs
@@ -3,7 +3,7 @@ defmodule Jerboa.Format.HeaderTest do
   alias Jerboa.Format.Header
   @i :crypto.strong_rand_bytes(div 96, 8)
   @struct %Jerboa.Format{class: :request, method: :binding, identifier: @i, body: <<>>}
-  @binary Header.encode(@struct)
+  @binary Map.fetch!(Header.encode(@struct), :header)
 
   describe "Header.encode/1" do
 

--- a/test/jerboa/format/head_test.exs
+++ b/test/jerboa/format/head_test.exs
@@ -50,7 +50,11 @@ defmodule Jerboa.Format.HeaderTest do
     end
 
     test "binding success response" do
-      assert <<2::6, 1>> == Header.Type.encode(%Jerboa.Format{class: :success, method: :binding})
+      params = %Jerboa.Format{class: :success, method: :binding}
+
+      bin = Header.Type.encode(params)
+
+      assert <<2::6, 1>> == bin
     end
   end
 


### PR DESCRIPTION
This introduces related functionality  and tests for the above scenario:

* encoding and decoding of the particular headers needed
* encoding the XORMappedAddress attribute for **IPv4** and **IPv6**
* encoding Attributes into Type-Length-Value fields
* improve test readability by introducing test and assertion helpers
* encoding bodies (one or more attributes)
* encoding complete messages (header and body)