### PR TITLE
Fix encoding/decoding of IPv6 XOR mapped addresses

### DIFF
--- a/lib/jerboa/format/body/attribute/xor_mapped_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_mapped_address.ex
@@ -83,19 +83,20 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddress do
     x |> binerize |> ip_4_decode |> binerize
   end
 
-  defp ip_6_encode(x, i) when tuple_size(x) === 16 do
+  defp ip_6_encode(x, i) when tuple_size(x) === 8 do
     x |> binerize |> ip_6_decode(i) |> binerize
   end
 
   defp ip_6_decode(x, i) do
-    <<a,b,c,d, e,f,g,h, i,j,k,l, m,n,o,p>> = :crypto.exor x, <<0x2112A442::32>> <> i
-    {a,b,c,d, e,f,g,h, i,j,k,l, m,n,o,p}
+    <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> =
+      :crypto.exor(x, <<0x2112A442::32>> <> i)
+    {a, b, c, d, e, f, g, h}
   end
 
   defp binerize({a, b, c, d}) do
     <<a, b, c, d>>
   end
-  defp binerize({a,b,c,d, e,f,g,h, i,j,k,l, m,n,o,p}) do
-    <<a,b,c,d, e,f,g,h, i,j,k,l, m,n,o,p>>
+  defp binerize({a, b, c, d, e, f, g, h}) do
+    <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
   end
 end

--- a/test/helper/xor_mapped_address.ex
+++ b/test/helper/xor_mapped_address.ex
@@ -15,7 +15,7 @@ defmodule Jerboa.Test.Helper.XORMappedAddress do
   end
 
   def ip_6_a do
-    :erlang.make_tuple(16, 0)
+    :erlang.make_tuple(8, 0)
   end
 
   def port, do: 0

--- a/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
+++ b/test/jerboa/format/body/attribute/xor_mapped_address_test.exs
@@ -129,7 +129,8 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddressTest do
   end
 
   defp x_ip6_addr(ip6_addr, identifier) do
-    bin_addr = ip6_addr |> Tuple.to_list() |> :erlang.list_to_binary()
+    {a, b, c, d, e, f, g, h} = ip6_addr
+    bin_addr = <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
     :crypto.exor(bin_addr, MagicCookie.encode() <> identifier)
   end
 
@@ -147,11 +148,15 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddressTest do
   end
 
   defp ip6_gen do
-    tuple(like: :erlang.make_tuple(16, byte()))
+    tuple(like: :erlang.make_tuple(8, two_bytes()))
   end
 
   defp byte do
     int(min: 0, max: 255)
+  end
+
+  defp two_bytes do
+    int(min: 0, max: 65_535)
   end
 
   defp address_family(<<_::8, 0x01::8, _::binary>>), do: "IPv4"
@@ -165,14 +170,13 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddressTest do
   end
 
   defp x_address(<<_::32, a::32-bits>>) do
-    tuplize(:crypto.exor(a, MagicCookie.encode()))
+    <<a, b, c, d>> = :crypto.exor(a, MagicCookie.encode())
+    {a, b, c, d}
   end
 
   defp x_address(<<_::32, a::128-bits>>, identifier) do
-    tuplize(:crypto.exor(a, MagicCookie.encode() <> identifier))
-  end
-
-  defp tuplize(b) do
-    b |> :erlang.binary_to_list |> List.to_tuple
+    <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> =
+      :crypto.exor(a, MagicCookie.encode() <> identifier)
+    {a, b, c, d, e, f, g, h}
   end
 end


### PR DESCRIPTION
Urgent fix. IPv6 addresses were encoded and decoded incorrectly. This PR fixes that.