### PR TITLE
Get rid of explicit server address and port in Jerboa Client

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 config :jerboa, :test,
-  server: %{name: "Google",
-            address: {74, 125, 143, 127},
-            port: 19_302}
+  server: [%{name: "Google",
+             address: {74, 125, 143, 127},
+             port: 19_302}
+          ]

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -5,19 +5,19 @@ defmodule Jerboa.Client do
 
   alias Jerboa.Client
 
-  @spec start :: Supervisor.on_start_child
-  def start do
-    Supervisor.start_child(Client.Supervisor, [])
+  @spec start(Keyword.t) :: Supervisor.on_start_child
+  def start(x) do
+    Supervisor.start_child(Client.Supervisor, [server(x)])
   end
 
-  @spec bind(GenServer.server, Keyword.t) :: {:inet.ip_address, :inet.port_number}
-  def bind(client, address: x, port: y) do
-    GenServer.call(client, {:bind, x, y})
+  @spec bind(GenServer.server) :: {:inet.ip_address, :inet.port_number}
+  def bind(client) do
+    GenServer.call(client, :bind)
   end
 
-  @spec persist(GenServer.server, Keyword.t) :: :ok
-  def persist(client, address: x, port: y) do
-    GenServer.call(client, {:persist, x, y}, 2 * timeout())
+  @spec persist(GenServer.server) :: :ok
+  def persist(client) do
+    GenServer.call(client, :persist, 2 * timeout())
   end
 
   @spec stop(GenServer.server) :: :ok |
@@ -27,8 +27,12 @@ defmodule Jerboa.Client do
     Supervisor.terminate_child(Client.Supervisor, client)
   end
 
+  defp server(server: %{address: a, port: p}) do
+    [address: a, port: p]
+  end
+
   @spec timeout :: non_neg_integer
-  def timeout do
+  defp timeout do
     Keyword.fetch!(Application.fetch_env!(:jerboa, :client), :timeout)
   end
 end

--- a/test/helper.ex
+++ b/test/helper.ex
@@ -4,16 +4,24 @@ defmodule Jerboa.Test.Helper do
   defmodule Server do
     @moduledoc false
 
-    def address do
-      configuration(:address)
+    def configuration(name) when is_binary(name) do
+      Enum.find(configuration(), select(name))
     end
 
-    def port do
-      configuration(:port)
+    defp configuration do
+      Keyword.fetch!(environment(), :server)
     end
 
-    defp configuration(key) do
-      get_in(Application.fetch_env!(:jerboa, :test), [:server, key])
+    defp select(name) do
+      fn %{name: ^name} ->
+        true
+        %{name: _} ->
+          false
+      end
+    end
+
+    defp environment do
+      Application.fetch_env!(:jerboa, :test)
     end
   end
 end

--- a/test/jerboa_test.exs
+++ b/test/jerboa_test.exs
@@ -1,10 +1,13 @@
 defmodule JerboaTest do
   use ExUnit.Case, async: true
 
-  @moduletag system: true
+  @moduletag :system
 
-  setup_all do
-    {:ok, alice} = Jerboa.Client.start()
+  setup do
+
+    ## Given:
+    import Jerboa.Test.Helper.Server, only: [configuration: 1]
+    {:ok, alice} = Jerboa.Client.start(server: configuration("Google"))
     on_exit fn ->
       :ok = Jerboa.Client.stop(alice)
     end
@@ -16,11 +19,8 @@ defmodule JerboaTest do
 
     test "send binding request; recieve success response", %{client: alice} do
 
-      ## Given:
-      import Jerboa.Test.Helper.Server
-
       ## When:
-      x = Jerboa.Client.bind(alice, address: address(), port: port())
+      x = Jerboa.Client.bind(alice)
 
       ## Then:
       assert family(x) == "IPv4"
@@ -28,12 +28,9 @@ defmodule JerboaTest do
 
     test "send binding indication", %{client: alice} do
 
-      ## Given:
-      import Jerboa.Test.Helper.Server
-
       ## When:
       x = for _ <- 1..3 do
-        Jerboa.Client.persist(alice, address: address(), port: port())
+        Jerboa.Client.persist(alice)
       end
 
       ## Then:

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(exclude: [system: true])
+ExUnit.start(exclude: [:system])


### PR DESCRIPTION
Configure the client through a server name in one of the config/*.exs
files in preparation to move system tests from Jerboa to Fennec.