### PR TITLE
Use Meta struct as a data source and sink during encoding and decoding

### DIFF
--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -46,11 +46,8 @@ defmodule Jerboa.Client.Worker do
   end
 
   defp binding_ do
-    %Jerboa.Params{
-      method: :binding,
-      identifier: :crypto.strong_rand_bytes(div(96, 8)),
-      body: <<>>
-    }
+    Params.new()
+    |> Params.put_method(:binding)
   end
 
   defp reflexive_candidate(params) do

--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -3,7 +3,7 @@ defmodule Jerboa.Format do
   Encode and decode the STUN wire format
   """
 
-  alias Jerboa.Format.{Header,Body}
+  alias Jerboa.Format.{Meta, Header,Body}
   alias Jerboa.Format.{HeaderLengthError, BodyLengthError}
   alias Jerboa.Params
 
@@ -13,13 +13,14 @@ defmodule Jerboa.Format do
   to the network
   """
   def encode(params) do
-    params
-    |> Body.encode
-    |> Header.encode
-    |> concatenate
+    %Meta{params: params}
+    |> Body.encode()
+    |> Header.encode()
+    |> concatenate()
   end
 
-  @spec decode!(binary) :: Params.t | no_return
+  @spec decode!(binary)
+    :: Params.t | {Params.t, extra :: binary} | no_return
   @doc """
   The same as `decode/1` but raises one of various exceptions if the
   binary doesn't encode a STUN message
@@ -28,36 +29,54 @@ defmodule Jerboa.Format do
     case decode(bin) do
       {:ok, params} ->
         params
+      {:ok, params, extra} ->
+        {params, extra}
       {:error, e} ->
         raise e
     end
   end
 
-  @spec decode(binary) :: {:ok, Params.t} | {:error, struct}
   @doc """
   Decode a binary into a complete set of STUN message parameters
 
   Return an `:ok` tuple or an `:error` tuple with an error struct if
-  the binary doesn't encode a STUN message.
+  the binary doesn't encode a STUN message. Returns `{:ok, params, extra}`
+  if given binary was longer than declared in STUN header.
   """
+  @spec decode(binary)
+    :: {:ok, Params.t} | {:ok, Params.t, extra :: binary} | {:error, struct}
   def decode(bin) when is_binary(bin) and byte_size(bin) < 20 do
     {:error, HeaderLengthError.exception(binary: bin)}
   end
   def decode(<<header::20-binary, body::binary>>) do
-    case Header.decode(%Params{header: header, body: body}) do
-      {:ok, %Params{body: body, length: length}} when byte_size(body) < length ->
+    meta = %Meta{header: header, body: body}
+    with {:ok, meta} <- decode_header(meta),
+         {:ok, meta} <- Body.decode(meta) do
+      maybe_with_extra(meta)
+    end
+  end
+
+  defp concatenate(%Meta{header: header, body: body}) do
+    header <> body
+  end
+
+  @spec decode_header(Meta.t) :: {:ok, Meta.t} | {:error, struct}
+  defp decode_header(meta) do
+    case Header.decode(meta) do
+      {:ok, %Meta{body: body, length: length}} when byte_size(body) < length ->
         {:error, BodyLengthError.exception(length: byte_size(body))}
-      {:ok, p = %Params{body: body, length: length}} when byte_size(body) > length ->
+      {:ok, %Meta{body: body, length: length} = meta} when byte_size(body) > length ->
         <<trimmed_body::size(length)-bytes, extra::binary>> = body
-        Body.decode(%{p | extra: extra, body: trimmed_body})
-      {:ok, x} ->
-        Body.decode(x)
+        {:ok, %{meta | extra: extra, body: trimmed_body}}
+      {:ok, _} = result ->
+        result
       {:error, _} = e ->
         e
     end
   end
 
-  defp concatenate(%Params{header: x, body: y}) do
-    x <> y
+  defp maybe_with_extra(%Meta{extra: <<>>} = meta), do: {:ok, meta.params}
+  defp maybe_with_extra(%Meta{extra: extra} = meta) do
+    {:ok, meta.params, extra}
   end
 end

--- a/lib/jerboa/format/body/attribute/data.ex
+++ b/lib/jerboa/format/body/attribute/data.ex
@@ -4,7 +4,7 @@ defmodule Jerboa.Format.Body.Attribute.Data do
   """
 
   alias Jerboa.Format.Body.Attribute.{Decoder,Encoder}
-  alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
   defstruct content: ""
 
@@ -22,21 +22,21 @@ defmodule Jerboa.Format.Body.Attribute.Data do
     @spec type_code(Data.t) :: integer
     def type_code(_), do: @type_code
 
-    @spec encode(Data.t, Params.t) :: binary
-    def encode(attr, _), do: Data.encode(attr)
+    @spec encode(Data.t, Meta.t) :: {Meta.t, binary}
+    def encode(attr, meta), do: {meta, Data.encode(attr)}
   end
 
   defimpl Decoder do
     alias Jerboa.Format.Body.Attribute.Data
 
-    @spec decode(Data.t, value :: binary, params :: Params.t)
-      :: {:ok, Data.t} | {:error, struct}
-    def decode(_, value, _), do: Data.decode(value)
+    @spec decode(Data.t, value :: binary, meta :: Meta.t)
+      :: {:ok, Meta.t, Data.t} | {:error, struct}
+    def decode(_, value, meta), do: Data.decode(value, meta)
   end
 
   @doc false
   def encode(%__MODULE__{content: content}) when is_binary(content), do: content
 
   @doc false
-  def decode(value), do: {:ok, %__MODULE__{content: value}}
+  def decode(value, meta), do: {:ok, meta, %__MODULE__{content: value}}
 end

--- a/lib/jerboa/format/body/attribute/lifetime.ex
+++ b/lib/jerboa/format/body/attribute/lifetime.ex
@@ -5,7 +5,7 @@ defmodule Jerboa.Format.Body.Attribute.Lifetime do
 
   alias Jerboa.Format.Body.Attribute.{Decoder,Encoder}
   alias Jerboa.Format.Lifetime.LengthError
-  alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
   defstruct duration: 0
 
@@ -27,16 +27,16 @@ defmodule Jerboa.Format.Body.Attribute.Lifetime do
     @spec type_code(Lifetime.t) :: integer
     def type_code(_), do: @type_code
 
-    @spec encode(Lifetime.t, Params.t) :: binary
-    def encode(attr, _), do: Lifetime.encode(attr)
+    @spec encode(Lifetime.t, Meta.t) :: {Meta.t, binary}
+    def encode(attr, meta), do: {meta, Lifetime.encode(attr)}
   end
 
   defimpl Decoder do
     alias Jerboa.Format.Body.Attribute.Lifetime
 
-    @spec decode(Lifetime.t, value :: binary, params :: Params.t)
-      :: {:ok, Lifetime.t} | {:error, struct}
-    def decode(_, value, _), do: Lifetime.decode(value)
+    @spec decode(Lifetime.t, value :: binary, meta :: Meta.t)
+      :: {:ok, Meta.t, Lifetime.t} | {:error, struct}
+    def decode(_, value, meta), do: Lifetime.decode(value, meta)
   end
 
   @doc false
@@ -47,11 +47,10 @@ defmodule Jerboa.Format.Body.Attribute.Lifetime do
   end
 
   @doc false
-  @spec decode(value :: binary) :: {:ok, Attribute.t} | {:error, struct}
-  def decode(<<duration::32>>) do
-    {:ok, %__MODULE__{duration: duration}}
+  def decode(<<duration::32>>, meta) do
+    {:ok, meta, %__MODULE__{duration: duration}}
   end
-  def decode(value) do
+  def decode(value, _) do
     {:error, LengthError.exception(length: byte_size(value))}
   end
 

--- a/lib/jerboa/format/body/attribute/nonce.ex
+++ b/lib/jerboa/format/body/attribute/nonce.ex
@@ -5,7 +5,7 @@ defmodule Jerboa.Format.Body.Attribute.Nonce do
 
   alias Jerboa.Format.Body.Attribute.{Decoder,Encoder}
   alias Jerboa.Format.Nonce.LengthError
-  alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
   defstruct value: ""
 
@@ -22,19 +22,19 @@ defmodule Jerboa.Format.Body.Attribute.Nonce do
     alias Jerboa.Format.Body.Attribute.Nonce
     @type_code 0x0015
 
-    @spec type_code(Data.t) :: integer
+    @spec type_code(Nonce.t) :: integer
     def type_code(_), do: @type_code
 
-    @spec encode(Nonce.t, Params.t) :: binary
-    def encode(attr, _), do: Nonce.encode(attr)
+    @spec encode(Nonce.t, Meta.t) :: {Meta.t, binary}
+    def encode(attr, meta), do: {meta, Nonce.encode(attr)}
   end
 
   defimpl Decoder do
     alias Jerboa.Format.Body.Attribute.Nonce
 
-    @spec decode(Nonce.t, value :: binary, params :: Params.t)
-      :: {:ok, Nonce.t} | {:error, struct}
-    def decode(_, value, _), do: Nonce.decode(value)
+    @spec decode(Nonce.t, value :: binary, meta :: Meta.t)
+      :: {:ok, Meta.t, Nonce.t} | {:error, struct}
+    def decode(_, value, meta), do: Nonce.decode(value, meta)
   end
 
   @doc false
@@ -47,10 +47,10 @@ defmodule Jerboa.Format.Body.Attribute.Nonce do
   end
 
   @doc false
-  def decode(value) do
+  def decode(value, meta) do
     length = String.length(value)
     if String.valid?(value) && length <= @max_chars do
-      {:ok, %__MODULE__{value: value}}
+      {:ok, meta, %__MODULE__{value: value}}
     else
       {:error, LengthError.exception(length: length)}
     end

--- a/lib/jerboa/format/body/attribute/realm.ex
+++ b/lib/jerboa/format/body/attribute/realm.ex
@@ -5,7 +5,7 @@ defmodule Jerboa.Format.Body.Attribute.Realm do
 
   alias Jerboa.Format.Body.Attribute.{Decoder, Encoder}
   alias Jerboa.Format.Realm.LengthError
-  alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
   defstruct value: ""
 
@@ -25,16 +25,16 @@ defmodule Jerboa.Format.Body.Attribute.Realm do
     @spec type_code(Realm.t) :: integer
     def type_code(_), do: @type_code
 
-    @spec encode(Realm.t, Params.t) :: binary
-    def encode(attr, _), do: Realm.encode(attr)
+    @spec encode(Realm.t, Meta.t) :: {Meta.t, binary}
+    def encode(attr, meta), do: {meta, Realm.encode(attr)}
   end
 
   defimpl Decoder do
     alias Jerboa.Format.Body.Attribute.Realm
 
-    @spec decode(Realm.t, value :: binary, Params.t)
-      :: {:ok, Realm.t} | {:error, struct}
-    def decode(_, value, _), do: Realm.decode(value)
+    @spec decode(Realm.t, value :: binary, Meta.t)
+      :: {:ok, Meta.t, Realm.t} | {:error, struct}
+    def decode(_, value, meta), do: Realm.decode(value, meta)
   end
 
   @doc false
@@ -47,10 +47,10 @@ defmodule Jerboa.Format.Body.Attribute.Realm do
   end
 
   @doc false
-  def decode(value) do
+  def decode(value, meta) do
     length = String.length(value)
     if String.valid?(value) && length <= @max_chars do
-      {:ok, %__MODULE__{value: value}}
+      {:ok, meta, %__MODULE__{value: value}}
     else
       {:error, LengthError.exception(length: length)}
     end

--- a/lib/jerboa/format/body/attribute/username.ex
+++ b/lib/jerboa/format/body/attribute/username.ex
@@ -5,7 +5,7 @@ defmodule Jerboa.Format.Body.Attribute.Username do
 
   alias Jerboa.Format.Body.Attribute.{Decoder,Encoder}
   alias Jerboa.Format.Username.LengthError
-  alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
   defstruct value: ""
 
@@ -26,16 +26,16 @@ defmodule Jerboa.Format.Body.Attribute.Username do
     @spec type_code(Username.t) :: integer
     def type_code(_), do: @type_code
 
-    @spec encode(Username.t, Params.t) :: binary
-    def encode(attr, _), do: Username.encode(attr)
+    @spec encode(Username.t, Meta.t) :: {Meta.t, binary}
+    def encode(attr, meta), do: {meta, Username.encode(attr)}
   end
 
   defimpl Decoder do
     alias Jerboa.Format.Body.Attribute.Username
 
-    @spec decode(Username.t, value :: binary, params :: Params.t)
+    @spec decode(Username.t, value :: binary, meta :: Meta.t)
       :: {:ok, Username.t} | {:error, struct}
-    def decode(_, value, _), do: Username.decode(value)
+    def decode(_, value, meta), do: Username.decode(value, meta)
   end
 
   @doc false
@@ -50,10 +50,10 @@ defmodule Jerboa.Format.Body.Attribute.Username do
   def encode(_), do: raise ArgumentError
 
   @doc false
-  def decode(value) do
+  def decode(value, meta) do
     length = byte_size(value)
     if String.valid?(value) && length <= @max_length do
-      {:ok, %__MODULE__{value: value}}
+      {:ok, meta, %__MODULE__{value: value}}
     else
       {:error, LengthError.exception(length: length)}
     end

--- a/lib/jerboa/format/exceptions.ex
+++ b/lib/jerboa/format/exceptions.ex
@@ -148,6 +148,20 @@ defmodule Jerboa.Format.Last2BitsError do
   end
 end
 
+defmodule Jerboa.Format.AttributeFormatError do
+  @moduledoc """
+  Error indicating that binary representation of attribute isn't
+  compliant with [STUN RFC](https://tools.ietf.org/html/rfc5389#section-15).
+  """
+
+  defexception [:message]
+
+  def exception(_opts \\ []) do
+    %__MODULE__{message: "length of attribute's value does not match length " <>
+      "declared in attribute's header"}
+  end
+end
+
 defmodule Jerboa.Format.ComprehensionError do
   @moduledoc """
 

--- a/lib/jerboa/format/header.ex
+++ b/lib/jerboa/format/header.ex
@@ -1,35 +1,45 @@
 defmodule Jerboa.Format.Header do
   @moduledoc false
 
-  alias Jerboa.Params
   alias Jerboa.Format.Header.{Type,Length,MagicCookie,Identifier}
+  alias Jerboa.Format.Meta
 
   @magic_cookie MagicCookie.encode
 
-  def encode(params) do
-    t = Type.encode(params)
-    l = Length.encode(params)
-    i = Identifier.encode(params)
-    %{params | header: encode(t, l, i)}
+  @spec encode(Meta.t) :: Meta.t
+  def encode(meta) do
+    type = Type.encode(meta)
+    length = Length.encode(meta)
+    id = Identifier.encode(meta)
+    %{meta | header: encode(type, length, id)}
   end
 
-  def decode(x = %Params{header: <<0::2, t::14-bits, l::16-bits, @magic_cookie::bytes, i::96-bits>>}) do
-    with {:ok, class, method} <- Type.decode(t),
+  defp encode(type, length, identifier) do
+    <<0::2, type::bits, length::bytes, @magic_cookie::bytes, identifier::bytes>>
+  end
+
+  @spec decode(Meta.t) :: {:ok, Meta.t} | {:error, struct}
+  def decode(%Meta{header: header, params: params} = meta) do
+    with {:ok, t, l, id}      <- destructure_header(header),
+         {:ok, class, method} <- Type.decode(t),
          {:ok, length}        <- Length.decode(l) do
-      {:ok, %{x | class: class, method: method, length: length, identifier: i}}
+      new_params = %{params | class: class, method: method, identifier: id}
+      new_meta = %{meta | length: length, params: new_params}
+      {:ok, new_meta}
     else
       {:error, _} = e ->
         e
     end
   end
-  def decode(%Params{header: <<0::2, _::30, _::128>> = header}) do
+
+  defp destructure_header(<<0::2, t::14-bits, l::16-bits,
+    @magic_cookie::bytes, id::96-bits>>) do
+    {:ok, t, l, id}
+  end
+  defp destructure_header(<<0::2, _::30, _::128>> = header) do
     {:error, Jerboa.Format.MagicCookieError.exception(header: header)}
   end
-  def decode(%Params{header: <<b::2, _::158>>}) do
+  defp destructure_header(<<b::2, _::158>>) do
     {:error, Jerboa.Format.First2BitsError.exception(bits: b)}
-  end
-
-  defp encode(type, length, identifier) do
-    <<0::2, type::bits, length::bytes, @magic_cookie::bytes, identifier::bytes>>
   end
 end

--- a/lib/jerboa/format/header/identifier.ex
+++ b/lib/jerboa/format/header/identifier.ex
@@ -2,8 +2,11 @@ defmodule Jerboa.Format.Header.Identifier do
   @moduledoc false
 
   alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
-  def encode(%Params{identifier: x}) when is_binary(x) and 96 === bit_size(x) do
+  @spec encode(Meta.t) :: binary
+  def encode(%Meta{params: %Params{identifier: x}})
+    when is_binary(x) and 96 === bit_size(x) do
     x
   end
 end

--- a/lib/jerboa/format/header/length.ex
+++ b/lib/jerboa/format/header/length.ex
@@ -2,13 +2,14 @@ defmodule Jerboa.Format.Header.Length do
   @moduledoc false
 
   alias Jerboa.Format.Last2BitsError
-  alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
-  def encode(%Params{body: b}) when is_binary(b) do
-    <<byte_size(b)::integer-unit(8)-size(2)>>
+  @spec encode(Meta.t) :: length :: binary
+  def encode(%Meta{body: b}) when is_binary(b) do
+    <<byte_size(b)::16>>
   end
 
-  def decode(x = <<_::14, 0::2>>) do
+  def decode(<<_::14, 0::2>> = x) do
     {:ok, :binary.decode_unsigned x}
   end
   def decode(bin_length) do

--- a/lib/jerboa/format/header/type.ex
+++ b/lib/jerboa/format/header/type.ex
@@ -3,6 +3,7 @@ defmodule Jerboa.Format.Header.Type do
 
   alias Jerboa.Format.UnknownMethodError
   alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
   defmodule Class do
     @moduledoc """
@@ -55,8 +56,9 @@ defmodule Jerboa.Format.Header.Type do
     def decode(<<m::12>>),     do: {:error, UnknownMethodError.exception(method: m)}
   end
 
-  def encode(%Params{class: x, method: y}) do
-    encode Class.encode(x), Method.encode(y)
+  @spec encode(Meta.t) :: type :: binary
+  def encode(%Meta{params: %Params{class: x, method: y}}) do
+    encode(Class.encode(x), Method.encode(y))
   end
 
   def decode(<<m11_7::5-bits, c1::1, m6_4::3-bits, c0::1, m3_0::4-bits>>) do

--- a/lib/jerboa/format/meta.ex
+++ b/lib/jerboa/format/meta.ex
@@ -1,0 +1,31 @@
+defmodule Jerboa.Format.Meta do
+  @moduledoc false
+
+  ## Struct getting passed along decoding and encoding process,
+  ## keeping decoded data and metadata used for further encoding
+  ## and decoding
+
+  alias Jerboa.Params
+
+  defstruct [header: <<>>, body: <<>>, length: 0, extra: <<>>,
+             options: [], params: %Params{}]
+
+  # Fields
+  # * `:header`- binary header of a message
+  # * `:body` - binary body of a message
+  # * `:length` - length of body as specified in STUN header
+  # * `:extra` - excess part of binary after `:length` bytes
+  #   (may happen when reading from TCP stream)
+  # * `:options` - additional options passed to encoding and
+  #    decoding
+  # * `:params` - params being encoded or container for the ones
+  #   being decoded
+  @type t :: %__MODULE__{
+    header: binary,
+    body: binary,
+    length: non_neg_integer,
+    extra: binary,
+    options: Keyword.t,
+    params: Params.t
+  }
+end

--- a/lib/jerboa/params.ex
+++ b/lib/jerboa/params.ex
@@ -1,19 +1,12 @@
 defmodule Jerboa.Params do
   @moduledoc """
   Data structure representing STUN message parameters
-
-  There are two main entities concerning the raw binary: the `header`
-  and the `body`. The body encapsulates what it means to encode and
-  decode zero or more attributes. It is not an entity described in the
-  RFC.
   """
 
-  alias Jerboa.Format.{Header,Body}
-  alias Header.Type.{Class, Method}
-  alias Body.Attribute
+  alias Jerboa.Format.Header.Type.{Class, Method}
+  alias Jerboa.Format.Body.Attribute
 
-  defstruct [:class, :method, :length, :identifier,
-             :header, :body, extra: <<>>, attributes: []]
+  defstruct [:class, :method, :identifier, attributes: []]
 
   @typedoc """
   The main data structure representing STUN message parameters
@@ -23,25 +16,15 @@ defmodule Jerboa.Params do
 
   * `class` is one of request, success or failure response, or indincation
   * `method` is a STUN (or TURN) message method described in one of the respective RFCs
-  * `length` is the length of the STUN message body in bytes
   * `identifier` is a unique transaction identifier
   * `attributes` is a list of STUN (or TURN) attributes as described in their
   respective RFCs
-  * `header` is the raw Elixir binary representation of the STUN header
-  initially encoding the `class`, `method`, `length`, `identifier`,
-  and magic cookie fields
-  * `body` is the raw Elixir binary representation of the STUN attributes
-  * `extra` are any bytes after the length given in the STUN header
   """
   @type t :: %__MODULE__{
     class: Class.t,
     method: Method.t,
-    length: non_neg_integer,
     identifier: binary,
     attributes: [Attribute.t],
-    header: binary,
-    body: binary,
-    extra: binary
   }
 
   @doc """
@@ -93,30 +76,6 @@ defmodule Jerboa.Params do
   """
   @spec get_id(t) :: binary | nil
   def get_id(%__MODULE__{identifier: id}), do: id
-
-  @doc """
-  Retrieves length field from params struct
-  """
-  @spec get_length(t) :: non_neg_integer | nil
-  def get_length(%__MODULE__{length: l}), do: l
-
-  @doc """
-  Retrieves body field from params struct
-  """
-  @spec get_body(t) :: binary | nil
-  def get_body(%__MODULE__{body: b}), do: b
-
-  @doc """
-  Retrieves header field from params struct
-  """
-  @spec get_header(t) :: binary | nil
-  def get_header(%__MODULE__{header: h}), do: h
-
-  @doc """
-  Retrieves excess binary field from params struct
-  """
-  @spec get_extra(t) :: binary | nil
-  def get_extra(%__MODULE__{extra: e}), do: e
 
   @doc """
   Retrieves all attributes from params struct

--- a/test/helper/format.ex
+++ b/test/helper/format.ex
@@ -1,13 +1,12 @@
 defmodule Jerboa.Test.Helper.Format do
   @moduledoc false
 
+  alias Jerboa.Params
+
   def binding_request do
-    %Jerboa.Params{
-      class: :request,
-      method: :binding,
-      identifier: Jerboa.Test.Helper.Header.identifier(),
-      body: <<>>
-    }
+    Params.new()
+    |> Params.put_class(:request)
+    |> Params.put_method(:binding)
   end
 
   def bytes_for_body(<<_::16, x::16, _::128, _::size(x)-bytes>>) do

--- a/test/jerboa/format/body/attribute/data_test.exs
+++ b/test/jerboa/format/body/attribute/data_test.exs
@@ -3,10 +3,11 @@ defmodule Jerboa.Format.Body.Attribute.DataTest do
   use Quixir
 
   alias Jerboa.Format.Body.Attribute.Data
+  alias Jerboa.Format.Meta
 
   test "decode/1 DATA attribute" do
     ptest content: string() do
-      assert {:ok, %Data{content: content}} == Data.decode(content)
+      assert {:ok, _, %Data{content: ^content}} = Data.decode(content, %Meta{})
     end
   end
 

--- a/test/jerboa/format/body/attribute/error_code_test.exs
+++ b/test/jerboa/format/body/attribute/error_code_test.exs
@@ -4,6 +4,7 @@ defmodule Jerboa.Format.Body.Attribute.ErrorCodeTest do
 
   alias Jerboa.Format.Body.Attribute.ErrorCode
   alias Jerboa.Format.ErrorCode.{FormatError, LengthError}
+  alias Jerboa.Format.Meta
 
   @moduletag :now
 
@@ -53,7 +54,7 @@ defmodule Jerboa.Format.Body.Attribute.ErrorCodeTest do
       ptest length: int(min: 0, max: 3), content: int(min: 0) do
         bin = <<content::size(length)-unit(8)>>
 
-        assert {:error, %LengthError{length: ^length}} = ErrorCode.decode(bin)
+        assert {:error, %LengthError{length: ^length}} = ErrorCode.decode(bin, %Meta{})
       end
     end
 
@@ -62,7 +63,7 @@ defmodule Jerboa.Format.Body.Attribute.ErrorCodeTest do
       reason = <<0xFFFF>>
       bin = binary_attr(code, reason)
 
-      assert {:error, error} = ErrorCode.decode(bin)
+      assert {:error, error} = ErrorCode.decode(bin, %Meta{})
       assert %FormatError{} = error
       assert error.code == code
       assert error.reason == reason
@@ -73,7 +74,7 @@ defmodule Jerboa.Format.Body.Attribute.ErrorCodeTest do
       reason = "alice has a cat"
       bin = binary_attr(code, reason)
 
-      assert {:error, error} = ErrorCode.decode(bin)
+      assert {:error, error} = ErrorCode.decode(bin, %Meta{})
       assert %FormatError{} = error
       assert error.code == code
       assert error.reason == reason
@@ -85,7 +86,7 @@ defmodule Jerboa.Format.Body.Attribute.ErrorCodeTest do
 
         bin = binary_attr(code, reason)
 
-        assert {:ok, attr} = ErrorCode.decode(bin)
+        assert {:ok, _, attr} = ErrorCode.decode(bin, %Meta{})
         assert attr.code == code
         assert attr.name
         assert attr.reason == reason

--- a/test/jerboa/format/body/attribute/lifetime_test.exs
+++ b/test/jerboa/format/body/attribute/lifetime_test.exs
@@ -4,13 +4,15 @@ defmodule Jerboa.Format.Body.Attribute.LifetimeTest do
 
   alias Jerboa.Format.Body.Attribute.Lifetime
   alias Jerboa.Format.Lifetime.LengthError
+  alias Jerboa.Format.Meta
 
   describe "decode/1" do
     test "LIFETIME attribute with valid length" do
       ptest duration: int(min: 0, max: Lifetime.max_duration) do
         lifetime = <<duration::32>>
 
-        assert {:ok, %Lifetime{duration: duration}} == Lifetime.decode(lifetime)
+        assert {:ok, _, %Lifetime{duration: ^duration}} =
+          Lifetime.decode(lifetime, %Meta{})
       end
     end
 
@@ -18,7 +20,8 @@ defmodule Jerboa.Format.Body.Attribute.LifetimeTest do
       ptest length: int(min: 5) do
         lifetime = for _ <- 1..length, into: <<>>, do: <<Enum.random(0..255)>>
 
-        assert {:error, %LengthError{length: ^length}} = Lifetime.decode(lifetime)
+        assert {:error, %LengthError{length: ^length}} =
+          Lifetime.decode(lifetime, %Meta{})
       end
     end
   end

--- a/test/jerboa/format/body/attribute/nonce_test.exs
+++ b/test/jerboa/format/body/attribute/nonce_test.exs
@@ -4,11 +4,12 @@ defmodule Jerboa.Format.Body.Attribute.NonceTest do
 
   alias Jerboa.Format.Body.Attribute.Nonce
   alias Jerboa.Format.Nonce.LengthError
+  alias Jerboa.Format.Meta
 
   describe "decode/1" do
     test "NONCE attribute of valid length" do
       ptest value: string(max: Nonce.max_chars) do
-        assert {:ok, %Nonce{value: value}} == Nonce.decode(value)
+        assert {:ok, _, %Nonce{value: ^value}} = Nonce.decode(value, %Meta{})
       end
     end
 
@@ -16,7 +17,8 @@ defmodule Jerboa.Format.Body.Attribute.NonceTest do
       length = Nonce.max_chars + 1
       value = String.duplicate("a", length)
 
-      assert {:error, %LengthError{length: ^length}} = Nonce.decode(value)
+      assert {:error, %LengthError{length: ^length}} =
+        Nonce.decode(value, %Meta{})
     end
   end
 

--- a/test/jerboa/format/body/attribute/realm_test.exs
+++ b/test/jerboa/format/body/attribute/realm_test.exs
@@ -4,11 +4,12 @@ defmodule Jerboa.Format.Body.Attribute.RealmTest do
 
   alias Jerboa.Format.Body.Attribute.Realm
   alias Jerboa.Format.Realm.LengthError
+  alias Jerboa.Format.Meta
 
   describe "decode/1" do
     test "REALM attribtue of valid length" do
       ptest value: string(max: Realm.max_chars) do
-        assert {:ok, %Realm{value: value}} == Realm.decode(value)
+        assert {:ok, _, %Realm{value: ^value}} = Realm.decode(value, %Meta{})
       end
     end
 
@@ -16,7 +17,7 @@ defmodule Jerboa.Format.Body.Attribute.RealmTest do
       length = Realm.max_chars + 1
       value = String.duplicate("a", length)
 
-      assert {:error, %LengthError{length: ^length}} = Realm.decode(value)
+      assert {:error, %LengthError{length: ^length}} = Realm.decode(value, %Meta{})
     end
   end
 

--- a/test/jerboa/format/body/attribute/username_test.exs
+++ b/test/jerboa/format/body/attribute/username_test.exs
@@ -4,11 +4,12 @@ defmodule Jerboa.Format.Body.Attribute.UsernameTest do
 
   alias Jerboa.Format.Body.Attribute.Username
   alias Jerboa.Format.Username.LengthError
+  alias Jerboa.Format.Meta
 
   describe "decode/1" do
     test "USERNAME attribute of valid length" do
       ptest value: string(max: Username.max_length, chars: :ascii) do
-        assert {:ok, %Username{value: value}} == Username.decode(value)
+        assert {:ok, _, %Username{value: ^value}} = Username.decode(value, %Meta{})
       end
     end
 
@@ -16,7 +17,7 @@ defmodule Jerboa.Format.Body.Attribute.UsernameTest do
       length = Username.max_length + 1
       value = String.duplicate("a", length)
 
-      assert {:error, %LengthError{length: ^length}} = Username.decode(value)
+      assert {:error, %LengthError{length: ^length}} = Username.decode(value, %Meta{})
     end
   end
 

--- a/test/jerboa/format/body/attribute_test.exs
+++ b/test/jerboa/format/body/attribute_test.exs
@@ -7,6 +7,7 @@ defmodule Jerboa.Format.Body.AttributeTest do
   alias Jerboa.Format.Body.Attribute.{XORMappedAddress, Lifetime, Data, Nonce,
                                       Username, Realm, ErrorCode}
   alias Jerboa.Params
+  alias Jerboa.Format.Meta
 
   import Jerboa.Test.Helper.Attribute, only: [total: 1, length_correct?: 2,
                                               type: 1, value: 1]
@@ -15,8 +16,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
 
     test "IPv4 XORMappedAddress as a TLV" do
       attr = XORMAHelper.struct(4)
+      meta = %Meta{params: Params.new}
 
-      bin = Attribute.encode %Params{}, attr
+      {_, bin} = Attribute.encode meta, attr
 
       assert type(bin) === 0x0020
       assert length_correct?(bin, total(address: 4, other: 4))
@@ -26,8 +28,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
       i = XORMAHelper.i()
       attr = XORMAHelper.struct(6)
       params = %Params{identifier: i}
+      meta = %Meta{params: params}
 
-      bin = Attribute.encode params, attr
+      {_, bin} = Attribute.encode meta, attr
 
       assert type(bin) === 0x0020
       assert length_correct?(bin, total(address: 16, other: 4))
@@ -35,8 +38,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
 
     test "LIFETIME as a TLV" do
       duration = 12_345
+      meta = %Meta{params: Params.new}
 
-      bin = Attribute.encode(Params.new, %Lifetime{duration: duration})
+      {_, bin} = Attribute.encode(meta, %Lifetime{duration: duration})
 
       assert type(bin) == 0x000D
       assert length_correct?(bin, total(duration: 4))
@@ -44,8 +48,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
 
     test "DATA as a TLV" do
       content = "Hello"
+      meta = %Meta{params: Params.new}
 
-      bin = Attribute.encode(Params.new, %Data{content: content})
+      {_, bin} = Attribute.encode(meta, %Data{content: content})
 
       assert type(bin) == 0x0013
       assert length_correct?(bin, total(content: byte_size(content)))
@@ -53,8 +58,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
 
     test "NONCE as a TLV" do
       value = "12345"
+      meta = %Meta{params: Params.new}
 
-      bin = Attribute.encode(Params.new, %Nonce{value: value})
+      {_, bin} = Attribute.encode(meta, %Nonce{value: value})
 
       assert type(bin) == 0x0015
       assert length_correct?(bin, total(value: byte_size(value)))
@@ -62,8 +68,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
 
     test "USERNAME as a TLV" do
       value = "Hello"
+      meta = %Meta{params: Params.new}
 
-      bin = Attribute.encode(Params.new, %Username{value: value})
+      {_, bin} = Attribute.encode(meta, %Username{value: value})
 
       assert type(bin) == 0x0006
       assert length_correct?(bin, total(value: byte_size(value)))
@@ -71,8 +78,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
 
     test "REALM as a TLV" do
       value = "Super Server"
+      meta = %Meta{params: Params.new}
 
-      bin = Attribute.encode(Params.new, %Realm{value: value})
+      {_, bin} = Attribute.encode(meta, %Realm{value: value})
 
       assert type(bin) == 0x0014
       assert length_correct?(bin, total(value: byte_size(value)))
@@ -81,8 +89,9 @@ defmodule Jerboa.Format.Body.AttributeTest do
     test "ERROR-CODE as a TLV" do
       code = 400
       reason = "alice has a cat"
+      meta = %Meta{params: Params.new}
 
-      bin = Attribute.encode(Params.new, %ErrorCode{code: code, reason: reason})
+      {_, bin} = Attribute.encode(meta, %ErrorCode{code: code, reason: reason})
 
       assert type(bin) == 0x0009
       assert length_correct?(bin, total(padding_and_code: 4, reason: byte_size(reason)))
@@ -92,58 +101,65 @@ defmodule Jerboa.Format.Body.AttributeTest do
   describe "Attribute.decode/3 is opposite to encode/2 for" do
     test "XOR-MAPPED-ADDRESS" do
       attr = %XORMappedAddress{family: :ipv4, address: {0, 0, 0, 0}, port: 0}
-      params = Params.new
-      bin = Attribute.encode(params, attr)
+      meta = %Meta{params: Params.new}
 
-      assert {:ok, attr} == Attribute.decode(params, 0x0020, value(bin))
+      {_, bin} = Attribute.encode(meta, attr)
+
+      assert {:ok, _, ^attr} = Attribute.decode(meta, 0x0020, value(bin))
     end
 
     test "LIFETIME" do
       attr = %Lifetime{duration: 12_345}
-      params = Params.new
-      bin = Attribute.encode(params, attr)
+      meta = %Meta{params: Params.new}
 
-      assert {:ok, attr} == Attribute.decode(params, 0x000D, value(bin))
+      {_, bin} = Attribute.encode(meta, attr)
+
+      assert {:ok, _, ^attr} = Attribute.decode(meta, 0x000D, value(bin))
     end
 
     test "DATA" do
       attr = %Data{content: "Hello"}
-      params = Params.new
-      bin = Attribute.encode(params, attr)
+      meta = %Meta{params: Params.new}
 
-      assert {:ok, attr} == Attribute.decode(params, 0x0013, value(bin))
+      {_, bin} = Attribute.encode(meta, attr)
+
+      assert {:ok, _, ^attr} = Attribute.decode(meta, 0x0013, value(bin))
     end
 
     test "NONCE" do
       attr = %Nonce{value: "12345"}
-      params = Params.new
-      bin = Attribute.encode(params, attr)
+      meta = %Meta{params: Params.new}
 
-      assert {:ok, attr} == Attribute.decode(params, 0x0015, value(bin))
+      {_, bin} = Attribute.encode(meta, attr)
+
+      assert {:ok, _, ^attr} = Attribute.decode(meta, 0x0015, value(bin))
     end
 
     test "USERNAME" do
       attr = %Username{value: "Hello"}
-      params = Params.new
-      bin = Attribute.encode(params, attr)
+      meta = %Meta{params: Params.new}
 
-      assert {:ok, attr} == Attribute.decode(params, 0x0006, value(bin))
+      {_, bin} = Attribute.encode(meta, attr)
+
+      assert {:ok, _, ^attr} = Attribute.decode(meta, 0x0006, value(bin))
     end
 
     test "REALM" do
       attr = %Realm{value: "Super Server"}
-      params = Params.new
-      bin = Attribute.encode(params, attr)
+      meta = %Meta{params: Params.new}
 
-      assert {:ok, attr} == Attribute.decode(params, 0x0014, value(bin))
+      {_, bin} = Attribute.encode(meta, attr)
+
+      assert {:ok, _, ^attr} = Attribute.decode(meta, 0x0014, value(bin))
     end
 
     test "ERROR-CODE" do
       attr = %ErrorCode{code: 400, name: :bad_request}
-      params = Params.new
-      bin = Attribute.encode(params, attr)
+      meta = %Meta{params: Params.new}
 
-      assert {:ok, ^attr} = Attribute.decode(params, 0x0009, value(bin))
+      {_, bin} = Attribute.encode(meta, attr)
+
+      assert {:ok, _, ^attr} = Attribute.decode(meta, 0x0009, value(bin))
     end
   end
 end

--- a/test/jerboa/format_test.exs
+++ b/test/jerboa/format_test.exs
@@ -66,9 +66,7 @@ defmodule Jerboa.FormatTest do
         packet = <<0::2, type::bits, 0::16, @magic::32, 0::96,
           extra::binary>>
 
-        {:ok, message} = Format.decode packet
-
-        assert ^extra = message.extra
+        assert {:ok, _, ^extra} = Format.decode packet
       end
     end
   end

--- a/test/jerboa/params_test.exs
+++ b/test/jerboa/params_test.exs
@@ -56,34 +56,6 @@ defmodule Jerboa.ParamsTest do
     assert id == Params.get_id(p)
   end
 
-  test "get_body/1 retrieves body field" do
-    body = "hello"
-    p = Params.new() |> Map.put(:body, body)
-
-    assert body == Params.get_body(p)
-  end
-
-  test "get_header/1 retrieves header field" do
-    header = "hello"
-    p = Params.new() |> Map.put(:header, header)
-
-    assert header == Params.get_header(p)
-  end
-
-  test "get_extra/1 retrieves extra field" do
-    extra = "hello"
-    p = Params.new() |> Map.put(:extra, extra)
-
-    assert extra == Params.get_extra(p)
-  end
-
-  test "get_length/1 retrieves length field" do
-    length = 120
-    p = Params.new() |> Map.put(:length, length)
-
-    assert length == Params.get_length(p)
-  end
-
   test "put_attrs/1 sets whole attributes list" do
     attrs = List.duplicate(%XORMappedAddress{}, 3)
 


### PR DESCRIPTION
At some point (as in encoding MESSAGE-INTEGRITY) we're going to need other fields for accumulating data throughout encoding process, and Params struct should only hold data which is of interest to end user. Thus, Meta was born, which wraps Params struct. It also holds other fields which were previously in Params, and is expected to  be extended with more.