### PR TITLE
MESSAGE-INTEGRITY encoding and decoding

### DIFF
--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -3,7 +3,7 @@ defmodule Jerboa.Format do
   Encode and decode the STUN wire format
   """
 
-  alias Jerboa.Format.{Meta, Header,Body, MessageIntegrity}
+  alias Jerboa.Format.{Meta, Header, Body, MessageIntegrity}
   alias Jerboa.Format.{HeaderLengthError, BodyLengthError}
   alias Jerboa.Params
 

--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -21,9 +21,10 @@ defmodule Jerboa.Format do
   or passed in options list. However attribute values will always override
   those found in options. Secret *must* be provided in option list.
 
-  If any of these values is missing, message integrity won't be applied
-  and encoding will succeed. None of these values will be validated,
-  so encoding will fail if, for example, provided username is an integer.
+  If any of these values are missing, message integrity won't be applied
+  and encoding will succeed. None of these values (username, realm or secret)
+  will be validated, so encoding will fail if, for example, provided username
+  is an integer.
 
   Note that passing these values in options list *won't add them to
   message attributes list*.
@@ -32,7 +33,7 @@ defmodule Jerboa.Format do
 
   * `:secret` - secret used for calculating message integrity
   * `:username` - username used for calculating message integrity
-    if USERNAME attribute can't be found in params struct
+    if USERNAME attribute can't be found in the params struct
   * `:realm` - realm used for calculating message integrity
     if REALM attribute can't be found in params struct
   """
@@ -74,7 +75,7 @@ defmodule Jerboa.Format do
   ## Verifying message integrity
 
   Similarly to `encode/2` decoder first looks for username and realm
-  in decoded message attributes or in the options list if there are
+  in the decoded message attributes or in the options list if there are
   no such attributes.
 
   However, note that we can't be sure what comes from the other end of the wire,

--- a/lib/jerboa/format/body.ex
+++ b/lib/jerboa/format/body.ex
@@ -7,8 +7,7 @@ defmodule Jerboa.Format.Body do
 
   @spec encode(Meta.t) :: Meta.t
   def encode(%Meta{params: params} = meta) do
-    {meta, body} = Enum.reduce params.attributes, {meta, <<>>}, &encode/2
-    %{meta | body: body}
+    Enum.reduce params.attributes, meta, &encode/2
   end
 
   @spec decode(Meta.t) :: {:ok, Meta.t} | {:error, struct}
@@ -22,11 +21,10 @@ defmodule Jerboa.Format.Body do
     end
   end
 
-  @spec encode(Attribute.t, {Meta.t, body :: binary})
-    :: {Meta.t, new_body :: binary}
-  defp encode(attr, {meta, body}) do
+  @spec encode(Attribute.t, Meta.t) :: Meta.t
+  defp encode(attr, meta) do
     {meta, encoded} = Attribute.encode(meta, attr)
-    {meta, body <> encoded <> padding(encoded)}
+    %{meta | body: meta.body <> encoded <> padding(encoded)}
   end
 
   @spec decode(Meta.t, not_decoded :: binary) :: {:ok, Meta.t} | {:error, struct}

--- a/lib/jerboa/format/body.ex
+++ b/lib/jerboa/format/body.ex
@@ -31,7 +31,8 @@ defmodule Jerboa.Format.Body do
   end
 
   @spec decode(Meta.t, not_decoded :: binary) :: {:ok, Meta.t} | {:error, struct}
-  defp decode(meta, <<@message_integrity::16, _::binary>> = body) do
+  defp decode(meta, <<@message_integrity::16, l::16, _v::size(l)-bytes,
+    _::binary>> = body) do
     MessageIntegrity.extract(meta, body)
   end
   defp decode(meta, <<t::16, l::16, v::bytes-size(l), r::binary>>) do

--- a/lib/jerboa/format/body.ex
+++ b/lib/jerboa/format/body.ex
@@ -4,6 +4,9 @@ defmodule Jerboa.Format.Body do
   alias Jerboa.Format.Body.Attribute
   alias Jerboa.Format.AttributeFormatError
   alias Jerboa.Format.Meta
+  alias Jerboa.Format.MessageIntegrity
+
+  @message_integrity MessageIntegrity.type_code
 
   @spec encode(Meta.t) :: Meta.t
   def encode(%Meta{params: params} = meta) do
@@ -28,8 +31,15 @@ defmodule Jerboa.Format.Body do
   end
 
   @spec decode(Meta.t, not_decoded :: binary) :: {:ok, Meta.t} | {:error, struct}
+  defp decode(meta, <<@message_integrity::16, _::binary>> = body) do
+    MessageIntegrity.extract(meta, body)
+  end
   defp decode(meta, <<t::16, l::16, v::bytes-size(l), r::binary>>) do
-    rest = strip(r, padding_length(l))
+    padding_length = padding_length(l)
+    rest = strip(r, padding_length)
+    new_length_up_to_integrity =
+      meta.length_up_to_integrity + 4 + l + padding_length
+    meta = %{meta | length_up_to_integrity: new_length_up_to_integrity}
     case Attribute.decode(meta, t, v) do
       {:ignore, meta} ->
         decode meta, rest

--- a/lib/jerboa/format/exceptions.ex
+++ b/lib/jerboa/format/exceptions.ex
@@ -449,3 +449,74 @@ defmodule Jerboa.Format.RequestedTransport.LengthError do
                   "Expected 4 bytes, found: #{length}"}
   end
 end
+
+defmodule Jerboa.Format.MessageIntegrity.FormatError do
+  @moduledoc """
+  Error indicating badly encoded MESSAGE-INTEGRITY attribute found
+  in STUN message
+
+  MESSAGE-INTEGRITY value must be 20 bytes long, any other value results
+  in this error.
+  """
+
+  defexception [:message]
+
+  def exception(_opts \\ []) do
+    %__MODULE__{message: "Invalid value length or declared length. MESSAGE-INTEGRIY value " <>
+      "must be 20 bytes long"}
+  end
+end
+
+defmodule Jerboa.Format.MessageIntegrity.UsernameMissingError do
+  @moduledoc """
+  Error indicating attempt to verify MESSAGE-INTEGRITY when USERNAME attribute
+  is not present in STUN message or username isn't provided in decoding options
+  """
+
+  defexception [:message]
+
+  def exception(_opts \\ []) do
+    %__MODULE__{message: "USERNAME attribute not found in message attributes " <>
+      "or in decoding options list"}
+  end
+end
+
+defmodule Jerboa.Format.MessageIntegrity.SecretMissingError do
+  @moduledoc """
+  Error indicating attempt to verify MESSAGE-INTEGRITY when secret isn't
+  provided in decoding options list
+  """
+
+  defexception [:message]
+
+  def exception(_opts \\ []) do
+    %__MODULE__{message: "secret not found in decoding options list"}
+  end
+end
+
+defmodule Jerboa.Format.MessageIntegrity.RealmMissingError do
+  @moduledoc """
+  Error indicating attempt to verify MESSAGE-INTEGRITY when REALM attribute
+  is not present in STUN message or realm isn't provided in decoding options
+  """
+
+  defexception [:message]
+
+  def exception(_opts \\ []) do
+    %__MODULE__{message: "REALM attribute not found in message attributes " <>
+      "or in decoding options list"}
+  end
+end
+
+defmodule Jerboa.Format.MessageIntegrity.VerificationError do
+  @moduledoc """
+  Error indicating that MESSAGE-INTEGRITY found in STUN message
+  is invalid given message attributes and options passed to decoder
+  """
+
+  defexception [:message]
+
+  def exception(_opts \\ []) do
+    %__MODULE__{message: "MESSAGE-INTEGRITY found in message is invalid"}
+  end
+end

--- a/lib/jerboa/format/header/identifier.ex
+++ b/lib/jerboa/format/header/identifier.ex
@@ -4,9 +4,11 @@ defmodule Jerboa.Format.Header.Identifier do
   alias Jerboa.Params
   alias Jerboa.Format.Meta
 
+  @bit_size 96
+
   @spec encode(Meta.t) :: binary
   def encode(%Meta{params: %Params{identifier: x}})
-    when is_binary(x) and 96 === bit_size(x) do
+    when is_binary(x) and bit_size(x) === @bit_size do
     x
   end
 end

--- a/lib/jerboa/format/message_integrity.ex
+++ b/lib/jerboa/format/message_integrity.ex
@@ -1,0 +1,87 @@
+defmodule Jerboa.Format.MessageIntegrity do
+  @moduledoc false
+
+  alias Jerboa.Format.Meta
+  alias Jerboa.Params
+  alias Jerboa.Format.Body.Attribute.Username
+  alias Jerboa.Format.Body.Attribute.Realm
+
+  @hash_length 20
+  @attr_length @hash_length + 4
+
+  @spec apply(Meta.t) :: Meta.t
+  def apply(meta) do
+    case assert_required_options(meta) do
+      :ok -> apply_message_integrity(meta)
+      _   -> meta
+    end
+  end
+
+  @spec assert_required_options(Meta.t) :: :ok | :error
+  defp assert_required_options(meta) do
+    with {:ok, _} <- get_username(meta),
+         {:ok, _} <- get_secret(meta),
+         {:ok, _} <- get_realm(meta) do
+      :ok
+    end
+  end
+
+  @spec get_username(Meta.t) :: {:ok, String.t} | :error
+  defp get_username(meta) do
+    from_attr = Params.get_attr(meta.params, Username)
+    from_opts = meta.options[:username]
+    cond do
+      from_attr -> {:ok, from_attr.value}
+      from_opts -> {:ok, from_opts}
+      true      -> :error
+    end
+  end
+
+  @spec get_secret(Meta.t) :: {:ok, String.t} | :error
+  defp get_secret(meta) do
+    case meta.options[:secret] do
+      nil -> :error
+      secret -> {:ok, secret}
+    end
+  end
+
+  @spec get_realm(Meta.t) :: {:ok, String.t} | :error
+  defp get_realm(meta) do
+    case Params.get_attr(meta.params, Realm) do
+      nil -> :error
+      realm -> {:ok, realm.value}
+    end
+  end
+
+  @spec apply_message_integrity(Meta.t) :: Meta.t
+  defp apply_message_integrity(meta) do
+    {:ok, username} = get_username(meta)
+    {:ok, realm} = get_realm(meta)
+    {:ok, secret} = get_secret(meta)
+    key = calculate_hash_key(username, realm, secret)
+    data = get_hash_subject(meta)
+    hash = :crypto.hmac(:sha, key, data)
+    %{meta | body: meta.body <> attribute(hash),
+             header: modify_header_length(meta.header)}
+  end
+
+  @spec calculate_hash_key(String.t, String.t, String.t) :: binary
+  defp calculate_hash_key(username, realm, secret) do
+    :crypto.hash :md5, [username, ":", realm, ":", secret]
+  end
+
+  @spec get_hash_subject(Meta.t) :: iolist
+  defp get_hash_subject(%Meta{header: header, body: body}) do
+    [modify_header_length(header), body]
+  end
+
+  @spec modify_header_length(header :: binary) :: binary
+  defp modify_header_length(<<0::2, type::14, length::16, rest::binary>>) do
+    <<0::2, type::14, (length + @attr_length)::16, rest::binary>>
+  end
+
+  @spec attribute(hash :: binary) :: attribute :: binary
+  defp attribute(hash) do
+    <<0x0008::16, @hash_length::16, hash::binary>>
+  end
+end

--- a/lib/jerboa/format/message_integrity.ex
+++ b/lib/jerboa/format/message_integrity.ex
@@ -5,15 +5,42 @@ defmodule Jerboa.Format.MessageIntegrity do
   alias Jerboa.Params
   alias Jerboa.Format.Body.Attribute.Username
   alias Jerboa.Format.Body.Attribute.Realm
+  alias Jerboa.Format.MessageIntegrity.{FormatError, UsernameMissingError,
+                                        RealmMissingError, SecretMissingError,
+                                        VerificationError}
 
+  @type_code 0x0008
   @hash_length 20
   @attr_length @hash_length + 4
+
+  def type_code, do: @type_code
+
+  @spec extract(Meta.t, binary) :: {:ok, Meta.t} | {:error, struct}
+  def extract(meta, <<@type_code::16, @hash_length::16,
+    hash::@hash_length-binary, _::binary>>) do
+    {:ok, %{meta | message_integrity: hash}}
+  end
+  def extract(_, _) do
+    {:error, FormatError.exception()}
+  end
 
   @spec apply(Meta.t) :: Meta.t
   def apply(meta) do
     case assert_required_options(meta) do
       :ok -> apply_message_integrity(meta)
       _   -> meta
+    end
+  end
+
+  @spec verify(Meta.t) :: {:ok, Meta.t} | {:error, struct}
+  def verify(meta) do
+    with true <- has_message_integrity?(meta),
+         :ok <- assert_required_options(meta),
+         :ok <- verify_message_integrity(meta) do
+      {:ok, meta}
+    else
+      false -> {:ok, meta}
+      {:error, _} = error -> error
     end
   end
 
@@ -26,48 +53,76 @@ defmodule Jerboa.Format.MessageIntegrity do
     end
   end
 
-  @spec get_username(Meta.t) :: {:ok, String.t} | :error
+  @spec get_username(Meta.t) :: {:ok, String.t} | {:error, struct}
   defp get_username(meta) do
     from_attr = Params.get_attr(meta.params, Username)
     from_opts = meta.options[:username]
     cond do
       from_attr -> {:ok, from_attr.value}
       from_opts -> {:ok, from_opts}
-      true      -> :error
+      true      -> {:error, UsernameMissingError.exception()}
     end
   end
 
-  @spec get_secret(Meta.t) :: {:ok, String.t} | :error
+  @spec get_secret(Meta.t) :: {:ok, String.t} | {:error, struct}
   defp get_secret(meta) do
     case meta.options[:secret] do
-      nil -> :error
+      nil -> {:error, SecretMissingError.exception()}
       secret -> {:ok, secret}
     end
   end
 
-  @spec get_realm(Meta.t) :: {:ok, String.t} | :error
+  @spec get_realm(Meta.t) :: {:ok, String.t} | {:error, struct}
   defp get_realm(meta) do
-    case Params.get_attr(meta.params, Realm) do
-      nil -> :error
-      realm -> {:ok, realm.value}
+    from_attr = Params.get_attr(meta.params, Realm)
+    from_opts = meta.options[:realm]
+    cond do
+      from_attr -> {:ok, from_attr.value}
+      from_opts -> {:ok, from_opts}
+      true      -> {:error, RealmMissingError.exception()}
     end
   end
 
   @spec apply_message_integrity(Meta.t) :: Meta.t
   defp apply_message_integrity(meta) do
-    {:ok, username} = get_username(meta)
-    {:ok, realm} = get_realm(meta)
-    {:ok, secret} = get_secret(meta)
-    key = calculate_hash_key(username, realm, secret)
+    key = calculate_hash_key(meta)
     data = get_hash_subject(meta)
-    hash = :crypto.hmac(:sha, key, data)
+    hash = calculate_hash(key, data)
     %{meta | body: meta.body <> attribute(hash),
              header: modify_header_length(meta.header)}
   end
 
-  @spec calculate_hash_key(String.t, String.t, String.t) :: binary
-  defp calculate_hash_key(username, realm, secret) do
+  @spec has_message_integrity?(Meta.t) :: boolean
+  defp has_message_integrity?(meta) do
+    case meta.message_integrity do
+      <<>> -> false
+      _ -> true
+    end
+  end
+
+  @spec verify_message_integrity(Meta.t) :: :ok | {:error, struct}
+  defp verify_message_integrity(meta) do
+    key = calculate_hash_key(meta)
+    data = meta |> amend_header_and_body() |> get_hash_subject()
+    hash = calculate_hash(key, data)
+    if hash == meta.message_integrity do
+      :ok
+    else
+      {:error, VerificationError.exception()}
+    end
+  end
+
+  @spec calculate_hash_key(Meta.t) :: binary
+  defp calculate_hash_key(meta) do
+    {:ok, username} = get_username(meta)
+    {:ok, realm} = get_realm(meta)
+    {:ok, secret} = get_secret(meta)
     :crypto.hash :md5, [username, ":", realm, ":", secret]
+  end
+
+  @spec calculate_hash(binary, binary) :: binary
+  def calculate_hash(key, data) do
+    :crypto.hmac(:sha, key, data)
   end
 
   @spec get_hash_subject(Meta.t) :: iolist
@@ -82,6 +137,18 @@ defmodule Jerboa.Format.MessageIntegrity do
 
   @spec attribute(hash :: binary) :: attribute :: binary
   defp attribute(hash) do
-    <<0x0008::16, @hash_length::16, hash::binary>>
+    <<@type_code::16, @hash_length::16, hash::binary>>
+  end
+
+  @spec amend_header_and_body(Meta.t) :: Meta.t
+  defp amend_header_and_body(meta) do
+    length = meta.length_up_to_integrity
+
+    <<0::2, type::14, _::16, header_rest::binary>> = meta.header
+    amended_header = <<0::2, type::14, length::16, header_rest::binary>>
+
+    <<amended_body::size(length)-bytes, _::binary>> = meta.body
+
+    %{meta | body: amended_body, header: amended_header}
   end
 end

--- a/lib/jerboa/format/message_integrity.ex
+++ b/lib/jerboa/format/message_integrity.ex
@@ -94,10 +94,7 @@ defmodule Jerboa.Format.MessageIntegrity do
 
   @spec has_message_integrity?(Meta.t) :: boolean
   defp has_message_integrity?(meta) do
-    case meta.message_integrity do
-      <<>> -> false
-      _ -> true
-    end
+    byte_size(meta.message_integrity) > 0
   end
 
   @spec verify_message_integrity(Meta.t) :: :ok | {:error, struct}

--- a/lib/jerboa/format/meta.ex
+++ b/lib/jerboa/format/meta.ex
@@ -8,6 +8,7 @@ defmodule Jerboa.Format.Meta do
   alias Jerboa.Params
 
   defstruct [header: <<>>, body: <<>>, length: 0, extra: <<>>,
+             message_integrity: <<>>, length_up_to_integrity: 0,
              options: [], params: %Params{}]
 
   # Fields
@@ -16,6 +17,10 @@ defmodule Jerboa.Format.Meta do
   # * `:length` - length of body as specified in STUN header
   # * `:extra` - excess part of binary after `:length` bytes
   #   (may happen when reading from TCP stream)
+  # * `:message_integrity` - value of message integrity hash
+  #   extracted from STUN message when decoding
+  # * `:length_up_to_integrity` - length of a message body up to
+  #   message integrity attribute, in bytes
   # * `:options` - additional options passed to encoding and
   #    decoding
   # * `:params` - params being encoded or container for the ones
@@ -25,6 +30,8 @@ defmodule Jerboa.Format.Meta do
     body: binary,
     length: non_neg_integer,
     extra: binary,
+    message_integrity: binary,
+    length_up_to_integrity: non_neg_integer,
     options: Keyword.t,
     params: Params.t
   }

--- a/test/jerboa/format/body_test.exs
+++ b/test/jerboa/format/body_test.exs
@@ -8,6 +8,7 @@ defmodule Jerboa.Format.BodyTest do
   alias Jerboa.Params
   alias Jerboa.Format.Body.Attribute.Data
   alias Jerboa.Format.Meta
+  alias Jerboa.Format.MessageIntegrity, as: MI
 
   describe "Body.encode/2" do
 
@@ -66,11 +67,18 @@ defmodule Jerboa.Format.BodyTest do
       assert {:error, error} = Body.decode(%Meta{body: body})
       assert %Format.AttributeFormatError{} = error
     end
+
+    test "fails if message integrity has invalid length" do
+      length = 19
+      body = <<0x0008::16, length::16, 0::size(length)-unit(8)>>
+
+      assert {:error, %MI.FormatError{}} = Body.decode(%Meta{body: body})
+    end
   end
 
   defp known_comprehension_required do
     [0x0020, 0x000D, 0x0013, 0x0015, 0x0006, 0x0014, 0x0009, 0x0012, 0x0016,
-     0x0019]
+     0x0019, 0x0008]
   end
 
   defp known_comprehension_optional do

--- a/test/jerboa/format/message_integrity_test.exs
+++ b/test/jerboa/format/message_integrity_test.exs
@@ -1,0 +1,135 @@
+defmodule Jerboa.Format.MessageIntegrityTest do
+  use ExUnit.Case
+  use Quixir
+
+  alias Jerboa.Params
+  alias Jerboa.Format.Header
+  alias Jerboa.Format.Body
+  alias Jerboa.Format.MessageIntegrity
+  alias Jerboa.Format.Meta
+  alias Jerboa.Format.Body.Attribute.{Nonce, Realm, Username}
+  alias Jerboa.Format.MessageIntegrity.RealmMissingError
+  alias Jerboa.Format.MessageIntegrity.UsernameMissingError
+  alias Jerboa.Format.MessageIntegrity.SecretMissingError
+  alias Jerboa.Format.MessageIntegrity.VerificationError
+
+  describe "apply/1" do
+    test "does not apply MI when secret is not given" do
+      options = [username: "alice", realm: "wonderland"]
+      meta = %Meta{options: options}
+
+      assert meta == MessageIntegrity.apply(meta)
+    end
+
+    test "does not apply MI when username is not given" do
+      options = [secret: "secret", realm: "wonderland"]
+      meta = %Meta{options: options}
+
+      assert meta == MessageIntegrity.apply(meta)
+    end
+
+    test "does not apply MI when realm is not given" do
+      options = [username: "alice", secret: "secret"]
+      meta = %Meta{options: options}
+
+      assert meta == MessageIntegrity.apply(meta)
+    end
+
+    test "applies MI when necessary values are passed as options" do
+      params =
+        Params.new()
+        |> Params.put_class(:request)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Nonce{value: "1234"})
+      options = [username: "alice", realm: "wonderland", secret: "secret"]
+      meta =
+        %Meta{params: params, options: options}
+        |> Body.encode()
+        |> Header.encode()
+
+      new_meta = MessageIntegrity.apply(meta)
+
+      assert byte_size(meta.body) + 24 == byte_size(new_meta.body)
+    end
+
+    test "applies MI when username as realm are passed as attributes" do
+      params =
+        Params.new()
+        |> Params.put_class(:request)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Nonce{value: "1234"})
+        |> Params.put_attr(%Username{value: "alice"})
+        |> Params.put_attr(%Realm{value: "wonderland"})
+      options = [secret: "secret"]
+      meta =
+        %Meta{params: params, options: options}
+        |> Body.encode()
+        |> Header.encode()
+
+      new_meta = MessageIntegrity.apply(meta)
+
+      assert byte_size(meta.body) + 24 == byte_size(new_meta.body)
+    end
+  end
+
+  describe "verify/1" do
+    test "does not verify if MI is empty" do
+      meta = %Meta{}
+
+      assert {:ok, meta} == MessageIntegrity.verify(meta)
+    end
+
+    test "fails when secret is not given" do
+      options = [username: "alice", realm: "wonderland"]
+      meta = %Meta{options: options, message_integrity: "abcd"}
+
+      assert {:error, %SecretMissingError{}} = MessageIntegrity.verify(meta)
+    end
+
+    test "fails when username is not given" do
+      options = [secret: "secret", realm: "wonderland"]
+      meta = %Meta{options: options, message_integrity: "abcd"}
+
+      assert {:error, %UsernameMissingError{}} = MessageIntegrity.verify(meta)
+    end
+
+    test "fails when realm is not given" do
+      options = [secret: "secret", username: "alice"]
+      meta = %Meta{options: options, message_integrity: "abcd"}
+
+      assert {:error, %RealmMissingError{}} = MessageIntegrity.verify(meta)
+    end
+
+    test "fails if extracted MI is not valid (values passed as options)" do
+      params =
+        Params.new()
+        |> Params.put_class(:request)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Nonce{value: "1234"})
+      options = [username: "alice", realm: "wonderland", secret: "secret"]
+      meta =
+        %Meta{params: params, options: options, message_integrity: "abcd"}
+        |> Body.encode()
+        |> Header.encode()
+
+      assert {:error, %VerificationError{}} = MessageIntegrity.verify(meta)
+    end
+
+    test "fails if extracted MI is not valid (values passed as attibutes)" do
+      params =
+        Params.new()
+        |> Params.put_class(:request)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Nonce{value: "1234"})
+        |> Params.put_attr(%Username{value: "alice"})
+        |> Params.put_attr(%Realm{value: "wonderland"})
+      options = [secret: "secret"]
+      meta =
+        %Meta{params: params, options: options, message_integrity: "abcd"}
+        |> Body.encode()
+        |> Header.encode()
+
+      assert {:error, %VerificationError{}} = MessageIntegrity.verify(meta)
+    end
+  end
+end

--- a/test/jerboa/format/message_integrity_test.exs
+++ b/test/jerboa/format/message_integrity_test.exs
@@ -13,12 +13,16 @@ defmodule Jerboa.Format.MessageIntegrityTest do
   alias Jerboa.Format.MessageIntegrity.SecretMissingError
   alias Jerboa.Format.MessageIntegrity.VerificationError
 
+  @mi_attr_length 24
+
   describe "apply/1" do
     test "does not apply MI when secret is not given" do
       options = [username: "alice", realm: "wonderland"]
-      meta = %Meta{options: options}
+      body_without_mi = <<>>
 
-      assert meta == MessageIntegrity.apply(meta)
+      meta = %Meta{options: options} |> MessageIntegrity.apply()
+
+      assert meta.body == body_without_mi
     end
 
     test "does not apply MI when username is not given" do
@@ -49,7 +53,7 @@ defmodule Jerboa.Format.MessageIntegrityTest do
 
       new_meta = MessageIntegrity.apply(meta)
 
-      assert byte_size(meta.body) + 24 == byte_size(new_meta.body)
+      assert byte_size(meta.body) + @mi_attr_length == byte_size(new_meta.body)
     end
 
     test "applies MI when username as realm are passed as attributes" do
@@ -68,13 +72,14 @@ defmodule Jerboa.Format.MessageIntegrityTest do
 
       new_meta = MessageIntegrity.apply(meta)
 
-      assert byte_size(meta.body) + 24 == byte_size(new_meta.body)
+      assert byte_size(meta.body) + @mi_attr_length == byte_size(new_meta.body)
     end
   end
 
   describe "verify/1" do
-    test "does not verify if MI is empty" do
-      meta = %Meta{}
+    test "changes nothing when MI is empty" do
+      empty_mi = <<>>
+      meta = %Meta{message_integrity: empty_mi}
 
       assert {:ok, meta} == MessageIntegrity.verify(meta)
     end

--- a/test/jerboa/format_test.exs
+++ b/test/jerboa/format_test.exs
@@ -107,7 +107,7 @@ defmodule Jerboa.FormatTest do
     assert {:ok, _} = Format.decode(bin, secret: secret)
   end
 
-  test "encode/2 and decode/2 apply and verify MI symmetrically" do
+  test "MI applied with encode/2 is verified byd decode/2 given same secret" do
     username = "alice"
     realm = "wonderland"
     secret = "secret"


### PR DESCRIPTION
Addresses #56 .

Providing options to `Format.encode/2` and `Format.decode/2` users can apply and verify MESSAGE-INTEGRITY in STUN messages.