### PR TITLE
Simple TURN client

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,29 +1,10 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
+config :logger,
+  handle_sasl_reports: true,
+  level: :info
 
-# You can configure for your application as:
-#
-#     config :jerboa, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:jerboa, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
+config :logger, :console,
+  metadata: [:jerboa_client, :jerboa_server]
 
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
 import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,4 @@
 use Mix.Config
+
+config :logger,
+  level: :warn

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -32,6 +32,7 @@ defmodule Jerboa.Client do
   @type address :: {ip, port_no}
   @type start_opts :: [start_opt]
   @type start_opt :: {:server, address}
+  @type error :: :bad_response | Jerboa.Format.Body.Attribute.ErrorCode.name
 
   alias Jerboa.Client
 
@@ -44,6 +45,8 @@ defmodule Jerboa.Client do
   ### Options
 
   * `:server` - required - a tuple with server's address and port
+  * `:username` - required - username used for authentication
+  * `:secret` - required - secret used for authentication
   """
   @spec start(options :: Keyword.t) :: Supervisor.on_start_child
   def start(opts) do
@@ -68,6 +71,15 @@ defmodule Jerboa.Client do
   @spec persist(t) :: :ok
   def persist(client) do
     GenServer.cast(client, :persist)
+  end
+
+  @doc """
+  Creates allocation on the server or returns relayed transport
+  address if client already has an allocation
+  """
+  @spec allocate(t) :: {:ok, address} | {:error, error}
+  def allocate(client) do
+    GenServer.call(client, :allocate)
   end
 
   @doc """

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -55,7 +55,7 @@ defmodule Jerboa.Client do
   """
   @spec bind(t) :: {ip, port_no} | no_return
   def bind(client) do
-    GenServer.call(client, :bind)
+    GenServer.call(client, :bind, 2 * timeout())
   end
 
   @doc """
@@ -63,7 +63,8 @@ defmodule Jerboa.Client do
   """
   @spec persist(t) :: :ok
   def persist(client) do
-    GenServer.call(client, :persist, 2 * timeout())
+    GenServer.cast(client, :persist)
+  end
   end
 
   @doc """

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -32,7 +32,9 @@ defmodule Jerboa.Client do
   @type address :: {ip, port_no}
   @type start_opts :: [start_opt]
   @type start_opt :: {:server, address}
-  @type error :: :bad_response | Jerboa.Format.Body.Attribute.ErrorCode.name
+  @type error :: :bad_response
+               | :no_allocation
+               | Jerboa.Format.Body.Attribute.ErrorCode.name
 
   alias Jerboa.Client
 
@@ -80,6 +82,14 @@ defmodule Jerboa.Client do
   @spec allocate(t) :: {:ok, address} | {:error, error}
   def allocate(client) do
     GenServer.call(client, :allocate)
+  end
+
+  @doc """
+  Tries to refresh the allocation on the server
+  """
+  @spec refresh(t) :: :ok | {:error, error}
+  def refresh(client) do
+    GenServer.call(client, :refresh)
   end
 
   @doc """

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -32,6 +32,8 @@ defmodule Jerboa.Client do
   @type address :: {ip, port_no}
   @type start_opts :: [start_opt]
   @type start_opt :: {:server, address}
+                   | {:username, String.t}
+                   | {:secret, String.t}
   @type error :: :bad_response
                | :no_allocation
                | Jerboa.Format.Body.Attribute.ErrorCode.name
@@ -41,7 +43,8 @@ defmodule Jerboa.Client do
   @doc """
   Starts STUN client process
 
-      iex> Jerboa.Client.start server: {{192, 168, 1, 20}, 3478}
+      iex> opts = [server: {{192, 168, 1, 20}, 3478}, username: "user", secret: "abcd"]
+      iex> Jerboa.Client.start(opts)
       {:ok, #PID<...>}
 
   ### Options

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -9,9 +9,7 @@ defmodule Jerboa.Client do
 
   (see `start/1` for configuration options)
 
-  Currently the only implemented STUN method is [Binding](), which allows a client to
-  query the server for its external IP address and port. To achieve that, this module
-  provides `bind/1` and `persist/1` functions.
+  ## Requesting server reflexive address
 
   The `bind/1` issues a Binding request to a server and returns reflexive IP address and port.
   If returned message is not a valid STUN message or it doesn't include XOR Mapped Address
@@ -24,6 +22,23 @@ defmodule Jerboa.Client do
   any response, but is an attempt to refresh NAT bindings in routers on the path to a server.
   Note that this is only an attempt, there is no guarantee that some router on the path
   won't rebind client's inside address and port.
+
+  ## Creating allocations
+
+  Allocation is a logical communication path between one client and multiple peers.
+  In practice a socket is created on the server, which peers can send data to,
+  and the server will forward this data to the client. Client can send data to
+  the server which will forward it to one or more peers.
+
+  Refer to [TURN RFC](https://trac.tools.ietf.org/html/rfc5766#section-2)
+  for a more detailed description.
+
+  `allocate/1` is used to request an allocation on the server. On success it returns
+  an `:ok` tuple, which contains allocated IP address and port number. Jerboa won't
+  try to request an allocation if it knows that the client already has one.
+
+  Note that allocations have an expiration time (RFC recommends 10 minutes), To refresh
+  an existing allocation one can use `refresh/1`.
 
   ## Logging
 

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -67,7 +67,7 @@ defmodule Jerboa.Client do
   """
   @spec bind(t) :: {:ok, address} | {:error, :bad_response} | no_return
   def bind(client) do
-    GenServer.call(client, :bind, 2 * timeout())
+    GenServer.call(client, :bind)
   end
 
   @doc """
@@ -102,10 +102,5 @@ defmodule Jerboa.Client do
     when error: :not_found | :simple_one_for_one
   def stop(client) do
     Supervisor.terminate_child(Client.Supervisor, client)
-  end
-
-  @spec timeout :: non_neg_integer
-  defp timeout do
-    Keyword.fetch!(Application.fetch_env!(:jerboa, :client), :timeout)
   end
 end

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -24,6 +24,16 @@ defmodule Jerboa.Client do
   any response, but is an attempt to refresh NAT bindings in routers on the path to a server.
   Note that this is only an attempt, there is no guarantee that some router on the path
   won't rebind client's inside address and port.
+
+  ## Logging
+
+  Client logs progress messages with `:debug` level, so Elixir's Logger needs to
+  be configured first to see them. It is recommended to allow Jerboa logging metadata,
+  i.e. `:jerboa_client` and `:jerboa_server`:
+
+      config :logger,
+        level: :debug,
+        metadata: [:jerboa_client, :jerboa_server]
   """
 
   @type t :: pid
@@ -102,5 +112,11 @@ defmodule Jerboa.Client do
     when error: :not_found | :simple_one_for_one
   def stop(client) do
     Supervisor.terminate_child(Client.Supervisor, client)
+    end
+
+  @doc false
+  @spec format_address(address) :: String.t
+  def format_address({ip, port}) do
+    "#{:inet.ntoa(ip)}:#{port}"
   end
 end

--- a/lib/jerboa/client/protocol.ex
+++ b/lib/jerboa/client/protocol.ex
@@ -1,0 +1,80 @@
+defmodule Jerboa.Client.Protocol do
+  @moduledoc false
+
+  ## Pure functions which construct requests or indications
+  ## and processes responses
+
+  alias Jerboa.Client
+  alias Jerboa.Client.Worker
+  alias Jerboa.Client.Protocol.Transaction
+  alias Jerboa.Params
+  alias Jerboa.Format
+  alias Jerboa.Format.Body.Attribute.XORMappedAddress, as: XMA
+
+  ## API
+
+  @spec init_state(Client.start_opts, Worker.socket) :: Worker.state
+  def init_state(opts, socket) do
+    %Worker{
+      socket: socket,
+      server: opts[:server]
+    }
+  end
+
+  @spec bind_req(Worker.state) :: Worker.state
+  def bind_req(state) do
+    bind(state, :request)
+  end
+
+  @spec bind_ind(Worker.state) :: Worker.state
+  def bind_ind(state) do
+    bind(state, :indication)
+  end
+
+  @spec eval_bind_resp(Worker.state)
+  :: {{:ok, mapped_address :: Client.address}, Worker.state}
+   | {{:error, :bad_response}, Worker.state}
+   | no_return
+  def eval_bind_resp(state) do
+    case validate_bind_resp(state) do
+      {:ok, new_state} ->
+        {{:ok, new_state.mapped_address}, new_state}
+      error ->
+      {error, state}
+    end
+  end
+
+  ## Internal functions
+
+  @spec bind(Worker.state, :request | :indication) :: Worker.state
+  defp bind(state, class) do
+    params =
+      Params.new()
+      |> Params.put_class(class)
+      |> Params.put_method(:binding)
+    msg = Format.encode(params)
+    fill_transaction(state, params.identifier, msg)
+  end
+
+  @spec fill_transaction(Worker.state, id :: binary, msg :: binary)
+    :: Worker.state
+  def fill_transaction(state, id, msg) do
+    %{state | transaction: %{state.transaction | req: msg, id: id}}
+  end
+
+  @spec validate_bind_resp(Worker.state) :: {:ok, Worker.state} | {:error, :bad_response}
+  defp validate_bind_resp(state) do
+    transaction = state.transaction
+    params = transaction.resp |> Format.decode!()
+    with true <- params.identifier == transaction.id,
+         %{address: addr, port: port} <- Params.get_attr(params, XMA),
+         :binding <- Params.get_method(params),
+         :success <- Params.get_class(params) do
+      mapped_address = {addr, port}
+      {:ok, %{state | mapped_address: mapped_address,
+                      transaction: %Transaction{}}}
+    else
+      _ -> {:error, :bad_response}
+    end
+  end
+end

--- a/lib/jerboa/client/protocol.ex
+++ b/lib/jerboa/client/protocol.ex
@@ -10,6 +10,9 @@ defmodule Jerboa.Client.Protocol do
   alias Jerboa.Params
   alias Jerboa.Format
   alias Jerboa.Format.Body.Attribute.XORMappedAddress, as: XMA
+  alias Jerboa.Format.Body.Attribute.XORRelayedAddress, as: XRA
+  alias Jerboa.Format.Body.Attribute.{RequestedTransport, Username, Realm,
+                                      Nonce, Lifetime, ErrorCode}
 
   ## API
 
@@ -17,7 +20,9 @@ defmodule Jerboa.Client.Protocol do
   def init_state(opts, socket) do
     %Worker{
       socket: socket,
-      server: opts[:server]
+      server: opts[:server],
+      username: opts[:username],
+      secret: opts[:secret]
     }
   end
 
@@ -42,6 +47,28 @@ defmodule Jerboa.Client.Protocol do
       error ->
       {error, state}
     end
+   end
+
+  @spec allocate_req(Worker.state) :: Worker.state
+  def allocate_req(state) do
+    params = allocate_params(state)
+    msg = encode_params(params, state)
+    fill_transaction(state, params.identifier, msg)
+  end
+
+  @spec eval_allocate_resp(Worker.state)
+    :: {{:ok, relayed_address :: Client.address}, Worker.state}
+     | {{:error, Client.error}, Worker.state}
+     | {:retry, Worker.state}
+  def eval_allocate_resp(state) do
+    case handle_allocate_resp(state) do
+      {:ok, new_state} ->
+        {{:ok, new_state.relayed_address}, new_state}
+      {:error, reason} ->
+        {{:error, reason}, %{state | transaction: %Transaction{}}}
+      {:retry, new_state} ->
+        {:retry, new_state}
+    end
   end
 
   ## Internal functions
@@ -54,15 +81,16 @@ defmodule Jerboa.Client.Protocol do
       |> Params.put_method(:binding)
     msg = Format.encode(params)
     fill_transaction(state, params.identifier, msg)
-  end
+   end
 
   @spec fill_transaction(Worker.state, id :: binary, msg :: binary)
     :: Worker.state
-  def fill_transaction(state, id, msg) do
+  defp fill_transaction(state, id, msg) do
     %{state | transaction: %{state.transaction | req: msg, id: id}}
   end
 
-  @spec validate_bind_resp(Worker.state) :: {:ok, Worker.state} | {:error, :bad_response}
+  @spec validate_bind_resp(Worker.state)
+    :: {:ok, Worker.state} | {:error, :bad_response}
   defp validate_bind_resp(state) do
     transaction = state.transaction
     params = transaction.resp |> Format.decode!()
@@ -75,6 +103,95 @@ defmodule Jerboa.Client.Protocol do
                       transaction: %Transaction{}}}
     else
       _ -> {:error, :bad_response}
+    end
+  end
+
+  @spec allocate_params(Worker.state) :: Params.t
+  defp allocate_params(state) do
+    base =
+      Params.new()
+      |> Params.put_class(:request)
+      |> Params.put_method(:allocate)
+      |> Params.put_attr(%RequestedTransport{})
+
+    if state.realm do
+      base
+      |> Params.put_attr(%Username{value: state.username})
+      |> Params.put_attr(%Realm{value: state.realm})
+      |> Params.put_attr(%Nonce{value: state.nonce})
+    else
+      base
+    end
+  end
+
+  @spec encode_params(Params.t, Worker.state) :: binary
+  defp encode_params(params, state) do
+    opts =
+      if state.realm do
+        [secret: state.secret, realm: state.realm, username: state.username]
+      else
+        []
+      end
+    Format.encode(params, opts)
+  end
+
+  @spec decode_message(binary, Worker.state) :: Params.t
+  def decode_message(msg, state) do
+    opts =
+      if state.realm do
+        [secret: state.secret, realm: state.realm, username: state.username]
+      else
+        []
+      end
+    Format.decode!(msg, opts)
+  end
+
+  @spec handle_allocate_resp(Worker.state)
+    :: {:ok, Worker.state} | {:error, Client.error} | {:retry, Worker.state}
+  defp handle_allocate_resp(state) do
+    transaction = state.transaction
+    params = transaction.resp |> decode_message(state)
+    with true <- params.identifier == transaction.id,
+         :allocate <- Params.get_method(params),
+         :success <- Params.get_class(params),
+         %{address: raddr, port: rport, family: :ipv4} <- Params.get_attr(params, XRA),
+         %{address: maddr, port: mport, family: :ipv4} <- Params.get_attr(params, XMA),
+         %{duration: lifetime} <- Params.get_attr(params, Lifetime) do
+      relayed_address = {raddr, rport}
+      mapped_address = {maddr, mport}
+      new_state = %{state | relayed_address: relayed_address,
+                            mapped_address: mapped_address,
+                            lifetime: lifetime,
+                            transaction: %Transaction{}}
+      {:ok, new_state}
+    else
+      :failure ->
+        handle_allocate_failure(state, params)
+      _ ->
+        {:error, :bad_response}
+    end
+  end
+
+  @spec handle_allocate_failure(Worker.state, resp :: Params.t)
+    :: {:retry, Worker.state} | {:error, Client.error}
+  defp handle_allocate_failure(state, params) do
+    realm_attr = Params.get_attr(params, Realm)
+    nonce_attr = Params.get_attr(params, Nonce)
+    error = Params.get_attr(params, ErrorCode)
+    cond do
+      is_nil error ->
+        {:error, :bad_response}
+      error.name == :unauthorized && is_nil(state.realm) && realm_attr && nonce_attr ->
+        new_state = %{state | transaction: %Transaction{},
+                              realm: realm_attr.value,
+                              nonce: nonce_attr.value}
+        {:retry, new_state}
+      error.name == :stale_nonce && nonce_attr ->
+        new_state = %{state | transaction: %Transaction{},
+                              nonce: nonce_attr.value}
+        {:retry, new_state}
+      true ->
+        {:error, error.name}
     end
   end
 end

--- a/lib/jerboa/client/protocol.ex
+++ b/lib/jerboa/client/protocol.ex
@@ -2,7 +2,7 @@ defmodule Jerboa.Client.Protocol do
   @moduledoc false
 
   ## Pure functions which construct requests or indications
-  ## and processes responses
+  ## and process responses
 
   alias Jerboa.Client
   alias Jerboa.Client.Worker
@@ -45,9 +45,9 @@ defmodule Jerboa.Client.Protocol do
       {:ok, new_state} ->
         {{:ok, new_state.mapped_address}, empty_transaction(new_state)}
       error ->
-      {error, state}
+        {error, state}
     end
-   end
+  end
 
   @spec allocate_req(Worker.state) :: Worker.state
   def allocate_req(state) do
@@ -227,8 +227,6 @@ defmodule Jerboa.Client.Protocol do
     |> Params.put_attr(%Nonce{value: state.nonce})
   end
 
-  require Logger
-
   @spec handle_refresh_resp(Worker.state)
     :: {:ok, Worker.state} | {:error, Client.error} | {:retry, Worker.state}
   defp handle_refresh_resp(state) do
@@ -252,7 +250,7 @@ defmodule Jerboa.Client.Protocol do
   defp handle_refresh_failure(state, params) do
     nonce_attr = Params.get_attr(params, Nonce)
     error = Params.get_attr(params, ErrorCode)
-       cond do
+    cond do
       is_nil error ->
         {:error, :bad_response}
       error.name == :stale_nonce && nonce_attr ->

--- a/lib/jerboa/client/protocol/transaction.ex
+++ b/lib/jerboa/client/protocol/transaction.ex
@@ -1,0 +1,11 @@
+defmodule Jerboa.Client.Protocol.Transaction do
+  @moduledoc false
+
+  defstruct req: <<>>, resp: <<>>, id: <<>>
+
+  @type t :: %__MODULE__{
+    req: binary,
+    resp: binary,
+    id: binary
+  }
+end

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -4,45 +4,49 @@ defmodule Jerboa.Client.Worker do
   use GenServer
 
   alias :gen_udp, as: UDP
-  alias Jerboa.Params
-  alias Jerboa.Format.Body.Attribute.XORMappedAddress
-  alias Jerboa.Format
+  alias Jerboa.Client
+  alias Jerboa.Client.Protocol
+  alias Jerboa.Client.Protocol.Transaction
 
-  import Kernel, except: [binding: 1]
+  defstruct [:server, :socket, :mapped_address, transaction: %Transaction{}]
 
-  defstruct [:server, :socket, :mapped_address]
-
-  @type address :: {Jerboa.Client.ip, Jerboa.Client.port_no}
-  @type t :: %__MODULE__{
-    server: address,
-    socket: UDP.socket,
-    mapped_address: address
+  @type socket :: UDP.socket
+  @type state :: %__MODULE__{
+    server: Client.address,
+    socket: socket,
+    transaction: Transaction.t,
+    mapped_address: Client.address,
   }
 
   @system_allocated_port 0
 
-  def start_link(x) do
-    GenServer.start_link(__MODULE__, x)
+  @spec start_link(Client.start_opts) :: GenServer.on_start
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
   end
 
-  def init(address: a, port: p) do
+  ## GenServer callbacks
+
+  def init(opts) do
     false = Process.flag(:trap_exit, true)
     {:ok, socket} = UDP.open(@system_allocated_port, [:binary, active: false])
-    {:ok,
-     %__MODULE__{server: {a, p}, socket: socket}}
+    state = Protocol.init_state(opts, socket)
+    {:ok, state}
   end
 
   def handle_call(:bind, _, state) do
-    msg = binding(:request)
-    params = request(msg, state)
-    state = %{state | mapped_address: mapped_address(params)}
-    {:reply, state.mapped_address, state}
+    {result, new_state} =
+      state
+      |> Protocol.bind_req()
+      |> send_req()
+      |> Protocol.eval_bind_resp()
+    {:reply, result, new_state}
   end
 
-
   def handle_cast(:persist, state) do
-    msg = binding(:indication)
-    indication(msg, state)
+    state
+    |> Protocol.bind_ind()
+    |> send_ind()
     {:noreply, state}
   end
 
@@ -50,35 +54,23 @@ defmodule Jerboa.Client.Worker do
     :ok = UDP.close(socket(state))
   end
 
-  defp server(%__MODULE__{server: s}) do
-    s
-  end
+  ## Internals
 
-  defp socket(%__MODULE__{socket: s}) do
-    s
-  end
+  defp server(%{server: server}), do: server
 
-  defp binding(class) do
-    Params.new()
-    |> Params.put_class(class)
-    |> Params.put_method(:binding)
-    |> Format.encode()
-  end
+  defp socket(%{socket: socket}), do: socket
 
-  defp mapped_address(params) do
-    xor_mapped_addr = Params.get_attr(params, XORMappedAddress)
-    {xor_mapped_addr.address, xor_mapped_addr.port}
-  end
-
-  defp request(msg, state) do
+  @spec send_req(state) :: state
+  defp send_req(%{transaction: %{req: req} = transaction} = state) do
     socket = socket(state)
     {address, port} = server(state)
-    :ok = UDP.send(socket, address, port, msg)
+    :ok = UDP.send(socket, address, port, req)
     {:ok, {^address, ^port, response}} = UDP.recv(socket, 0, timeout())
-    Format.decode!(response)
+    %{state | transaction: %{transaction | resp: response}}
   end
 
-  defp indication(msg, state) do
+  @spec send_ind(state) :: :ok
+  defp send_ind(%{transaction: %{req: msg}} = state) do
     socket = socket(state)
     {address, port} = server(state)
     :ok = UDP.send(socket, address, port, msg)

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -107,7 +107,7 @@ defmodule Jerboa.Client.Worker do
     socket = socket(state)
     {address, port} = server(state)
     :ok = UDP.send(socket, address, port, req)
-    {:ok, {^address, ^port, response}} = UDP.recv(socket, 0, timeout())
+    {:ok, {^address, ^port, response}} = UDP.recv(socket, 0)
     %{state | transaction: %{transaction | resp: response}}
   end
 
@@ -116,10 +116,6 @@ defmodule Jerboa.Client.Worker do
     socket = socket(state)
     {address, port} = server(state)
     :ok = UDP.send(socket, address, port, msg)
-  end
-
-  defp timeout do
-    Keyword.fetch!(Application.fetch_env!(:jerboa, :client), :timeout)
   end
 
   @spec request_allocation(state) :: {result :: term, state}

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,6 @@ defmodule Jerboa.Mixfile do
 
   def application do
     [mod: {Jerboa.Client.Application, []},
-     env: [client: [timeout: 5 * 1000]],
      extra_applications: [:logger]]
   end
 

--- a/test/jerboa/client/protocol_test.exs
+++ b/test/jerboa/client/protocol_test.exs
@@ -13,7 +13,7 @@ defmodule Jerboa.Client.ProtocolTest do
   test "bind_req/1 retuns encoded binding request" do
     %{transaction: %{req: msg}} = Protocol.bind_req(%Worker{})
 
-    params= msg |> Format.decode!()
+    params = msg |> Format.decode!()
 
     assert Params.get_class(params) == :request
     assert Params.get_method(params) == :binding

--- a/test/jerboa/client/protocol_test.exs
+++ b/test/jerboa/client/protocol_test.exs
@@ -1,0 +1,118 @@
+defmodule Jerboa.Client.ProtocolTest do
+  use ExUnit.Case
+
+  alias Jerboa.Client.Protocol
+  alias Jerboa.Client.Protocol.Transaction
+  alias Jerboa.Client.Worker
+  alias Jerboa.Params
+  alias Jerboa.Format
+  alias Jerboa.Format.Body.Attribute.XORMappedAddress
+
+  test "bind_req/1 retuns encoded binding request" do
+    %{transaction: %{req: msg}} = Protocol.bind_req(%Worker{})
+
+    params= msg |> Format.decode!()
+
+    assert Params.get_class(params) == :request
+    assert Params.get_method(params) == :binding
+    assert Params.get_attrs(params) == []
+  end
+
+  test "bind_ind/1 returns encoded binding indication" do
+    %{transaction: %{req: msg}} = Protocol.bind_ind(%Worker{})
+
+    params = msg |> Format.decode!()
+
+    assert Params.get_class(params) == :indication
+    assert Params.get_method(params) == :binding
+    assert Params.get_attrs(params) == []
+  end
+
+  describe "eval_bind_resp/2" do
+
+    ## TODO: refactor params creation to helper function
+    ## and assertion on empty transaction
+
+    test "returns mapped address given worker state with valid response" do
+      address = {0, 0, 0, 0}
+      port = 0
+      mapped_address = %XORMappedAddress{address: address, port: port,
+                                         family: :ipv4}
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:binding)
+        |> Params.put_attr(mapped_address)
+      t_id = resp_params.identifier
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {{:ok, {^address, ^port}}, new_state} =
+        Protocol.eval_bind_resp(state)
+      assert new_state.transaction == %Transaction{}
+    end
+
+    test "returns error on error response" do
+      address = {0, 0, 0, 0}
+      port = 0
+      mapped_address = %XORMappedAddress{address: address, port: port,
+                                         family: :ipv4}
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:binding)
+        |> Params.put_attr(mapped_address)
+      t_id = resp_params.identifier
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {{:error, _}, _} = Protocol.eval_bind_resp(state)
+    end
+
+    test "returns error on invalid transaction id" do
+      address = {0, 0, 0, 0}
+      port = 0
+      mapped_address = %XORMappedAddress{address: address, port: port,
+                                         family: :ipv4}
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:binding)
+        |> Params.put_attr(mapped_address)
+      t_id = Params.generate_id()
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {{:error, _}, _} = Protocol.eval_bind_resp(state)
+    end
+
+    test "returns error on invalid STUN method" do
+      address = {0, 0, 0, 0}
+      port = 0
+      mapped_address = %XORMappedAddress{address: address, port: port,
+                                         family: :ipv4}
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(mapped_address)
+      t_id = resp_params.identifier
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {{:error, _}, _} = Protocol.eval_bind_resp(state)
+    end
+
+    test "returns error on message without XOR-MAPPED-ADDRESS" do
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+      t_id = resp_params.identifier
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {{:error, _}, _} = Protocol.eval_bind_resp(state)
+    end
+  end
+end

--- a/test/jerboa/client/protocol_test.exs
+++ b/test/jerboa/client/protocol_test.exs
@@ -6,7 +6,9 @@ defmodule Jerboa.Client.ProtocolTest do
   alias Jerboa.Client.Worker
   alias Jerboa.Params
   alias Jerboa.Format
-  alias Jerboa.Format.Body.Attribute.XORMappedAddress
+  alias Jerboa.Format.Body.Attribute.{XORMappedAddress, RequestedTransport,
+                                      Username, Realm, Nonce, XORRelayedAddress,
+                                      Lifetime, ErrorCode}
 
   test "bind_req/1 retuns encoded binding request" do
     %{transaction: %{req: msg}} = Protocol.bind_req(%Worker{})
@@ -29,10 +31,6 @@ defmodule Jerboa.Client.ProtocolTest do
   end
 
   describe "eval_bind_resp/2" do
-
-    ## TODO: refactor params creation to helper function
-    ## and assertion on empty transaction
-
     test "returns mapped address given worker state with valid response" do
       address = {0, 0, 0, 0}
       port = 0
@@ -113,6 +111,320 @@ defmodule Jerboa.Client.ProtocolTest do
       state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
 
       assert {{:error, _}, _} = Protocol.eval_bind_resp(state)
+    end
+  end
+
+  describe "allocate_req/1" do
+    test "returns unsigned message if credentials are not known yet" do
+      state = %Worker{}
+
+      %{transaction: %{req: msg}} = state |> Protocol.allocate_req()
+      params = Format.decode!(msg)
+
+      assert :request == Params.get_class(params)
+      assert :allocate == Params.get_method(params)
+      assert %RequestedTransport{protocol: :udp} ==
+        Params.get_attr(params, RequestedTransport)
+    end
+
+    test "returns signed message if credentials are known" do
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      state = %Worker{username: username, realm: realm, secret: secret, nonce: nonce}
+
+      %{transaction: %{req: msg}} = state |> Protocol.allocate_req()
+      params = Format.decode!(msg, secret: secret)
+
+      assert :request == Params.get_class(params)
+      assert :allocate == Params.get_method(params)
+      assert %RequestedTransport{protocol: :udp} ==
+        Params.get_attr(params, RequestedTransport)
+      assert %Username{value: username} == Params.get_attr(params, Username)
+      assert %Realm{value: realm} == Params.get_attr(params, Realm)
+      assert %Nonce{value: nonce} == Params.get_attr(params, Nonce)
+    end
+  end
+
+  describe "eval_allocate_resp/1" do
+    test "returns error on response with wrong method" do
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:binding)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns error on response with invalid transaction id" do
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+      t_id = Params.generate_id()
+
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns error on response without XOR-RELAYED-ADDRESS" do
+      address = {0, 0, 0, 0}
+      port = 0
+      duration = 600
+      mapped_address = %XORMappedAddress{address: address, port: port,
+                                         family: :ipv4}
+      lifetime = %Lifetime{duration: duration}
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+        |> Params.put_attr(mapped_address)
+        |> Params.put_attr(lifetime)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns error on response without XOR-MAPPED-ADDRESS" do
+      address = {0, 0, 0, 0}
+      port = 0
+      duration = 600
+      relayed_address = %XORRelayedAddress{address: address, port: port,
+                                           family: :ipv4}
+      lifetime = %Lifetime{duration: duration}
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+        |> Params.put_attr(relayed_address)
+        |> Params.put_attr(lifetime)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns error on response without LIFETIME" do
+      address = {0, 0, 0, 0}
+      port = 0
+      mapped_address = %XORMappedAddress{address: address, port: port,
+                                         family: :ipv4}
+      relayed_address = %XORRelayedAddress{address: address, port: port,
+                                           family: :ipv4}
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+        |> Params.put_attr(relayed_address)
+        |> Params.put_attr(mapped_address)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns error on IPv6 XOR-RELAYED-ADDRESS" do
+      ipv4_address = {0, 0, 0, 0}
+      ipv6_address = {0, 0, 0, 0, 0, 0, 0, 0}
+      port = 0
+      duration = 600
+      mapped_address = %XORMappedAddress{address: ipv4_address, port: port,
+                                         family: :ipv4}
+      relayed_address = %XORRelayedAddress{address: ipv6_address, port: port,
+                                           family: :ipv6}
+      lifetime = %Lifetime{duration: duration}
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+        |> Params.put_attr(mapped_address)
+        |> Params.put_attr(relayed_address)
+        |> Params.put_attr(lifetime)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns error on IPv6 XOR-MAPPED-ADDRESS" do
+      ipv4_address = {0, 0, 0, 0}
+      ipv6_address = {0, 0, 0, 0, 0, 0, 0, 0}
+      port = 0
+      duration = 600
+      mapped_address = %XORMappedAddress{address: ipv6_address, port: port,
+                                         family: :ipv6}
+      relayed_address = %XORRelayedAddress{address: ipv4_address, port: port,
+                                           family: :ipv4}
+      lifetime = %Lifetime{duration: duration}
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+        |> Params.put_attr(mapped_address)
+        |> Params.put_attr(relayed_address)
+        |> Params.put_attr(lifetime)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns :retry and updates nonce if error response is :stale_nonce" do
+      realm = "wonderland"
+      old_nonce = "dcba"
+      new_nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: new_nonce})
+        |> Params.put_attr(%ErrorCode{name: :stale_nonce})
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, nonce: old_nonce}
+
+      assert {:retry, new_state} = Protocol.eval_allocate_resp(state)
+      assert new_state.nonce == new_nonce
+    end
+
+    test "returns :retry and updates realm and nonce if error response is :unauthorized" do
+      realm = "wonderland"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+        |> Params.put_attr(%ErrorCode{name: :unauthorized})
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {:retry, new_state} = Protocol.eval_allocate_resp(state)
+      assert new_state.nonce == nonce
+      assert new_state.realm == realm
+    end
+
+    test "returns error if error response doesn't have error code attribute" do
+      realm = "wonderland"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_allocate_resp(state)
+    end
+
+    test "returns relayed address on valid allocate response" do
+      address = {0, 0, 0, 0}
+      port = 0
+      duration = 600
+      mapped_address = %XORMappedAddress{address: address, port: port,
+                                         family: :ipv4}
+      relayed_address = %XORRelayedAddress{address: address, port: port,
+                                           family: :ipv4}
+      lifetime = %Lifetime{duration: duration}
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: nonce})
+        |> Params.put_attr(mapped_address)
+        |> Params.put_attr(relayed_address)
+        |> Params.put_attr(lifetime)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:ok, {^address, ^port}}, new_state} = Protocol.eval_allocate_resp(state)
+      assert new_state.mapped_address == {address, port}
+      assert new_state.relayed_address == {address, port}
+      assert new_state.lifetime == duration
     end
   end
 end


### PR DESCRIPTION
Extended client process to issue allocate and refresh requests and react to responses. It also includes retries when stale nonce or unathorized errors are returned from the server. Also moved STUN/TURN processing to `Jerboa.Client.Protocol` module.