### PR TITLE
Change behaviour of MESSAGE-INTEGRITY verification stage

### DIFF
--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -79,10 +79,10 @@ defmodule Jerboa.Format do
   no such attributes.
 
   Verification stage of decoding will never cause a decoding failure.
-  To indicate what happened during verification, there are to fields
+  To indicate what happened during verification, there are two fields
   in `Jerboa.Params` struct: `:signed?` and `:verified?`.
 
-  `:signed?` is set to true **only** if message being decoded has
+  `:signed?` is set to true **only** if the message being decoded has
   a MESSAGE-INTEGRITY attribute included. `:verified?` can never
   be true if `:signed?` is false (because there is simply nothing to
   verify).

--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -78,13 +78,22 @@ defmodule Jerboa.Format do
   in the decoded message attributes or in the options list if there are
   no such attributes.
 
-  However, note that we can't be sure what comes from the other end of the wire,
-  so we don't know if those attributes will be there (STUN/TURN RFCs define such
-  behaviour, e.g. TURN server never includes USERNAME attribute in responses).
+  Verification stage of decoding will never cause a decoding failure.
+  To indicate what happened during verification, there are to fields
+  in `Jerboa.Params` struct: `:signed?` and `:verified?`.
 
-  Decoding will fail if necessary values (username, realm and secret) can't
-  be found, so it's better to always pass these values as options just to be
-  sure.
+  `:signed?` is set to true **only** if message being decoded has
+  a MESSAGE-INTEGRITY attribute included. `:verified?` can never
+  be true if `:signed?` is false (because there is simply nothing to
+  verify).
+
+  `:verified?` is only set to true when:
+  * the message is `:signed?`
+  * username, realm in the message attributes, or were passed as options
+    and secret was passed as option
+  * MESSAGE-INTEGRITY was successfully verified using algorithm described in RFC
+
+  Otherwise, it's set to false.
 
   ## Available options
 

--- a/lib/jerboa/format/exceptions.ex
+++ b/lib/jerboa/format/exceptions.ex
@@ -467,60 +467,6 @@ defmodule Jerboa.Format.MessageIntegrity.FormatError do
   end
 end
 
-defmodule Jerboa.Format.MessageIntegrity.UsernameMissingError do
-  @moduledoc """
-  Error indicating attempt to verify MESSAGE-INTEGRITY when USERNAME attribute
-  is not present in STUN message or username isn't provided in decoding options
-  """
-
-  defexception [:message]
-
-  def exception(_opts \\ []) do
-    %__MODULE__{message: "USERNAME attribute not found in message attributes " <>
-      "or in decoding options list"}
-  end
-end
-
-defmodule Jerboa.Format.MessageIntegrity.SecretMissingError do
-  @moduledoc """
-  Error indicating attempt to verify MESSAGE-INTEGRITY when secret isn't
-  provided in decoding options list
-  """
-
-  defexception [:message]
-
-  def exception(_opts \\ []) do
-    %__MODULE__{message: "secret not found in decoding options list"}
-  end
-end
-
-defmodule Jerboa.Format.MessageIntegrity.RealmMissingError do
-  @moduledoc """
-  Error indicating attempt to verify MESSAGE-INTEGRITY when REALM attribute
-  is not present in STUN message or realm isn't provided in decoding options
-  """
-
-  defexception [:message]
-
-  def exception(_opts \\ []) do
-    %__MODULE__{message: "REALM attribute not found in message attributes " <>
-      "or in decoding options list"}
-  end
-end
-
-defmodule Jerboa.Format.MessageIntegrity.VerificationError do
-  @moduledoc """
-  Error indicating that MESSAGE-INTEGRITY found in STUN message
-  is invalid given message attributes and options passed to decoder
-  """
-
-  defexception [:message]
-
-  def exception(_opts \\ []) do
-    %__MODULE__{message: "MESSAGE-INTEGRITY found in message is invalid"}
-  end
-end
-
 defmodule Jerboa.Format.DontFragment.ValuePresentError do
   @moduledoc """
   Error indicating that DONT-FRAGMENT found in STUN message

--- a/lib/jerboa/params.ex
+++ b/lib/jerboa/params.ex
@@ -6,7 +6,8 @@ defmodule Jerboa.Params do
   alias Jerboa.Format.Header.Type.{Class, Method}
   alias Jerboa.Format.Body.Attribute
 
-  defstruct [:class, :method, :identifier, attributes: []]
+  defstruct [:class, :method, :identifier, attributes: [],
+             signed?: false, verified?: false]
 
   @typedoc """
   The main data structure representing STUN message parameters
@@ -19,12 +20,20 @@ defmodule Jerboa.Params do
   * `identifier` is a unique transaction identifier
   * `attributes` is a list of STUN (or TURN) attributes as described in their
   respective RFCs
+  * `signed?` indicates wheter STUN message was signed with MESSAGE-INTEGRITY
+    attribute - it isn't important when encoding a message
+  * `verified?` - indicates wheter MESSAGE-INTEGRIY from STUN message was
+    successfully verified. Same as `signed?`, it's only relevant when decoding
+    messages. Note that messages which are `verified?` are also `signed?`, but not
+    the other way around.
   """
   @type t :: %__MODULE__{
     class: Class.t,
     method: Method.t,
     identifier: binary,
     attributes: [Attribute.t],
+    signed?: boolean,
+    verified?: boolean
   }
 
   @doc """


### PR DESCRIPTION
Previously failed verification caused failure of whole decoding process. This commit intoduces new fields in Params struct (`:verified?` and `:signed?`) which can be used to inspect result of verification.

Addresses #81 