### PR TITLE
Allow adding new attributes while using jerboa as a dep

### DIFF
--- a/lib/jerboa/format/body/attribute/data.ex
+++ b/lib/jerboa/format/body/attribute/data.ex
@@ -17,10 +17,6 @@ defmodule Jerboa.Format.Body.Attribute.Data do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.Data
-    @type_code 0x0013
-
-    @spec type_code(Data.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(Data.t, Meta.t) :: {Meta.t, binary}
     def encode(attr, meta), do: {meta, Data.encode(attr)}

--- a/lib/jerboa/format/body/attribute/dont_fragment.ex
+++ b/lib/jerboa/format/body/attribute/dont_fragment.ex
@@ -18,10 +18,6 @@ defmodule Jerboa.Format.Body.Attribute.DontFragment do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.DontFragment
-    @type_code 0x001A
-
-    @spec type_code(DontFragment.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(DontFragment.t, Meta.t) :: {Meta.t, binary}
     def encode(_attr, meta), do: {meta, DontFragment.encode()}

--- a/lib/jerboa/format/body/attribute/error_code.ex
+++ b/lib/jerboa/format/body/attribute/error_code.ex
@@ -59,10 +59,6 @@ defmodule Jerboa.Format.Body.Attribute.ErrorCode do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.ErrorCode
-    @type_code 0x0009
-
-    @spec type_code(ErrorCode.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(ErrorCode.t, Meta.t) :: {Meta.t, binary}
     def encode(attr, meta), do: {meta, ErrorCode.encode(attr)}

--- a/lib/jerboa/format/body/attribute/lifetime.ex
+++ b/lib/jerboa/format/body/attribute/lifetime.ex
@@ -22,10 +22,6 @@ defmodule Jerboa.Format.Body.Attribute.Lifetime do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.Lifetime
-    @type_code 0x000D
-
-    @spec type_code(Lifetime.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(Lifetime.t, Meta.t) :: {Meta.t, binary}
     def encode(attr, meta), do: {meta, Lifetime.encode(attr)}

--- a/lib/jerboa/format/body/attribute/nonce.ex
+++ b/lib/jerboa/format/body/attribute/nonce.ex
@@ -20,10 +20,6 @@ defmodule Jerboa.Format.Body.Attribute.Nonce do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.Nonce
-    @type_code 0x0015
-
-    @spec type_code(Nonce.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(Nonce.t, Meta.t) :: {Meta.t, binary}
     def encode(attr, meta), do: {meta, Nonce.encode(attr)}

--- a/lib/jerboa/format/body/attribute/realm.ex
+++ b/lib/jerboa/format/body/attribute/realm.ex
@@ -20,10 +20,6 @@ defmodule Jerboa.Format.Body.Attribute.Realm do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.Realm
-    @type_code 0x0014
-
-    @spec type_code(Realm.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(Realm.t, Meta.t) :: {Meta.t, binary}
     def encode(attr, meta), do: {meta, Realm.encode(attr)}

--- a/lib/jerboa/format/body/attribute/requested_transport.ex
+++ b/lib/jerboa/format/body/attribute/requested_transport.ex
@@ -25,10 +25,6 @@ defmodule Jerboa.Format.Body.Attribute.RequestedTransport do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.RequestedTransport
-    @type_code 0x0019
-
-    @spec type_code(RequestedTransport.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(RequestedTransport.t, Meta.t) :: {Meta.t, binary}
     def encode(attr, meta), do: {meta, RequestedTransport.encode(attr)}

--- a/lib/jerboa/format/body/attribute/username.ex
+++ b/lib/jerboa/format/body/attribute/username.ex
@@ -21,10 +21,6 @@ defmodule Jerboa.Format.Body.Attribute.Username do
 
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.Username
-    @type_code 0x0006
-
-    @spec type_code(Username.t) :: integer
-    def type_code(_), do: @type_code
 
     @spec encode(Username.t, Meta.t) :: {Meta.t, binary}
     def encode(attr, meta), do: {meta, Username.encode(attr)}

--- a/lib/jerboa/format/body/attribute/xor_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_address.ex
@@ -18,7 +18,7 @@ defmodule Jerboa.Format.Body.Attribute.XORAddress do
   @magic_cookie Jerboa.Format.Header.MagicCookie.value
   @most_significant_magic_16 @magic_cookie >>> 16
 
-  defmacro __using__(type_code: type_code) do
+  defmacro __using__(_opts) do
     quote do
       defstruct [:family, :address, :port]
 
@@ -29,8 +29,6 @@ defmodule Jerboa.Format.Body.Attribute.XORAddress do
       }
 
       defimpl Jerboa.Format.Body.Attribute.Encoder do
-        def type_code(_), do: unquote(type_code)
-
         def encode(attr, meta) do
           value =
             Jerboa.Format.Body.Attribute.XORAddress.encode(attr, meta.params)

--- a/lib/jerboa/format/body/attribute/xor_mapped_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_mapped_address.ex
@@ -6,5 +6,5 @@ defmodule Jerboa.Format.Body.Attribute.XORMappedAddress do
 
   alias Jerboa.Format.Body.Attribute.XORAddress
 
-  use XORAddress, type_code: 0x0020
+  use XORAddress
 end

--- a/lib/jerboa/format/body/attribute/xor_peer_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_peer_address.ex
@@ -6,5 +6,5 @@ defmodule Jerboa.Format.Body.Attribute.XORPeerAddress do
 
   alias Jerboa.Format.Body.Attribute.XORAddress
 
-  use XORAddress, type_code: 0x0012
+  use XORAddress
 end

--- a/lib/jerboa/format/body/attribute/xor_relayed_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_relayed_address.ex
@@ -6,5 +6,5 @@ defmodule Jerboa.Format.Body.Attribute.XORRelayedAddress do
 
   alias Jerboa.Format.Body.Attribute.XORAddress
 
-  use XORAddress, type_code: 0x0016
+  use XORAddress
 end


### PR DESCRIPTION
This is based on the regular protocol dispatching for the Encoder protocol
and configuration-driven function clauses generation for the Decoder protocol.