### PR TITLE
Add TURN permissions mechanism

### DIFF
--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -121,6 +121,22 @@ defmodule Jerboa.Client do
   end
 
   @doc """
+  Creates permission on the allocation for the given peer
+  address
+
+  If permission is already installed for the given address,
+  the permission will be refreshed.
+
+  ## Example
+
+      iex> create_permission client, {192, 168, 22, 111}
+  """
+  @spec create_permission(t, peer :: ip) :: :ok | {:error, error}
+  def create_permission(client, peer) do
+    GenServer.call(client, {:create_permission, peer})
+  end
+
+  @doc """
   Stops the client
   """
   @spec stop(t) :: :ok | {:error, error}

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -65,7 +65,7 @@ defmodule Jerboa.Client do
 
   alias Jerboa.Client
 
-  @doc """
+  @doc ~S"""
   Starts STUN client process
 
       iex> opts = [server: {{192, 168, 1, 20}, 3478}, username: "user", secret: "abcd"]

--- a/lib/jerboa/client/protocol.ex
+++ b/lib/jerboa/client/protocol.ex
@@ -269,15 +269,15 @@ defmodule Jerboa.Client.Protocol do
       {:ok, new_state}
     else
       :failure ->
-           handle_refresh_failure(state, params)
+           maybe_retry_with_stale_nonce(state, params)
       _ ->
         {:error, :bad_response}
     end
   end
 
-  @spec handle_refresh_failure(Worker.state, resp :: Params.t)
+  @spec maybe_retry_with_stale_nonce(Worker.state, resp :: Params.t)
     :: {:retry, Worker.state} | {:error, Client.error}
-  defp handle_refresh_failure(state, params) do
+  defp maybe_retry_with_stale_nonce(state, params) do
     nonce_attr = Params.get_attr(params, Nonce)
     error = Params.get_attr(params, ErrorCode)
     cond do

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -12,11 +12,13 @@ defmodule Jerboa.Client.Worker do
 
   defstruct [:server, :socket, :mapped_address, :username, :secret,
              :realm, :nonce, :relayed_address, :lifetime, :lifetime_timer_ref,
-             transaction: %Transaction{}]
+             transaction: %Transaction{}, permissions: []]
 
   @default_retries 1
+  @permission_expiry 5  * 60 * 1_000 # 5 minutes
 
   @type socket :: UDP.socket
+  @type permission :: {peer_addr :: Client.ip, timer_red :: reference}
   @type state :: %__MODULE__{
     server: Client.address,
     socket: socket,
@@ -28,7 +30,8 @@ defmodule Jerboa.Client.Worker do
     nonce: String.t,
     relayed_address: Client.address,
     lifetime: non_neg_integer,
-    lifetime_timer_ref: reference
+    lifetime_timer_ref: reference,
+    permissions: [permission]
   }
 
   @system_allocated_port 0
@@ -79,6 +82,18 @@ defmodule Jerboa.Client.Worker do
       {:reply, result, new_state}
     end
   end
+  def handle_call({:create_permission, peer_address}, _, state) do
+    unless state.relayed_address do
+      Logger.debug fn ->
+        "No allocation present on the server, create permission request blocked"
+      end
+      {:reply, {:error, :no_allocation}, state}
+    else
+      {result, new_state} =
+        request_permission(state, peer_address, @default_retries)
+      {:reply, result, new_state}
+    end
+  end
 
   def handle_cast(:persist, state) do
     state
@@ -88,11 +103,16 @@ defmodule Jerboa.Client.Worker do
   end
 
   def handle_info(:allocation_expired, state) do
-    Logger.debug "Allocation timed out"
+    Logger.debug fn -> "Allocation timed out" end
     new_state = %{state | lifetime_timer_ref: nil,
                           relayed_address: nil,
-                          lifetime: nil}
+                          lifetime: nil,
+                          permissions: []}
     {:noreply, new_state}
+  end
+  def handle_info({:permission_expired, peer_addr}, state) do
+    Logger.debug fn -> "Permission for #{:inet.ntoa(peer_addr)} expired" end
+    {:noreply, remove_permission(state, peer_addr)}
   end
 
   def terminate(_, state) do
@@ -176,11 +196,60 @@ defmodule Jerboa.Client.Worker do
     end
   end
 
+  @spec request_permission(state, peer :: Client.ip,
+    retries_left :: pos_integer) :: {result :: term, state}
+  def request_permission(state, peer_addr, retries_left) do
+    {result, new_state} =
+      state
+      |> Protocol.create_perm_req(peer_addr)
+      |> send_req()
+      |> Protocol.eval_create_perm_resp()
+    with :retry <- result,
+         n when n > 0 <- retries_left do
+      Logger.debug fn ->
+        "Received error create permission response, retrying.."
+      end
+      request_permission(new_state, peer_addr, n - 1)
+    else
+      :ok ->
+        {result, update_permission(new_state, peer_addr)}
+      _ ->
+        {result, new_state}
+    end
+  end
+
   @spec setup_logger_metadata(state) :: any
   defp setup_logger_metadata(%{socket: socket, server: server}) do
     {:ok, port} = :inet.port(socket)
     metadata = [jerboa_client: "#{inspect self()}:#{port}",
                 jerboa_server: Client.format_address(server)]
     Logger.metadata(metadata)
+  end
+
+  @spec update_permission(state, Client.ip) :: state
+  defp update_permission(state, peer_addr) do
+    remove_permission(state, peer_addr)
+    |> add_permission(peer_addr)
+  end
+
+  @spec remove_permission(state, Client.ip) :: state
+  defp remove_permission(state, peer_addr) do
+    {removed, remaining} =
+      Enum.split_with(state.permissions, fn {addr, _} -> addr == peer_addr end)
+    case removed do
+      [{^peer_addr, timer_ref}] ->
+        Process.cancel_timer timer_ref
+      _ ->
+        :ok
+    end
+    %{state | permissions: remaining}
+  end
+
+  @spec add_permission(state, Client.ip) :: state
+  defp add_permission(state, peer_addr) do
+    timer_ref = Process.send_after self(),
+      {:permission_expired, peer_addr}, @permission_expiry
+    permission = {peer_addr, timer_ref}
+    %{state | permissions: [permission | state.permissions]}
   end
 end

--- a/lib/jerboa/format/body/attribute/xor_address.ex
+++ b/lib/jerboa/format/body/attribute/xor_address.ex
@@ -28,6 +28,18 @@ defmodule Jerboa.Format.Body.Attribute.XORAddress do
         port: :inet.port_number
       }
 
+      @doc """
+      Creates new address struct and fills address family
+      based on passed IP address format
+      """
+      @spec new(address :: :inet.ip_address, port :: :inet.port_number) :: t
+      def new({_, _, _, _} = addr, port) do
+        %__MODULE__{family: :ipv4, address: addr, port: port}
+      end
+      def new({_, _, _, _, _, _, _, _} = addr, port) do
+        %__MODULE__{family: :ipv6, address: addr, port: port}
+      end
+
       defimpl Jerboa.Format.Body.Attribute.Encoder do
         def type_code(_), do: unquote(type_code)
 

--- a/test/jerboa/client/protocol_test.exs
+++ b/test/jerboa/client/protocol_test.exs
@@ -441,7 +441,6 @@ defmodule Jerboa.Client.ProtocolTest do
     %{transaction: %{req: msg}} = state |> Protocol.refresh_req()
     params = msg |> Format.decode!(secret: secret)
 
-
     assert Params.get_class(params) == :request
     assert Params.get_method(params) == :refresh
     assert Params.get_attr(params, Realm) == %Realm{value: realm}
@@ -608,7 +607,6 @@ defmodule Jerboa.Client.ProtocolTest do
 
     %{transaction: %{req: msg}} = state |> Protocol.create_perm_req(peer_addr)
     params = msg |> Format.decode!(secret: secret)
-
 
     assert Params.get_class(params) == :request
     assert Params.get_method(params) == :create_permission

--- a/test/jerboa/client/protocol_test.exs
+++ b/test/jerboa/client/protocol_test.exs
@@ -8,7 +8,7 @@ defmodule Jerboa.Client.ProtocolTest do
   alias Jerboa.Format
   alias Jerboa.Format.Body.Attribute.{XORMappedAddress, RequestedTransport,
                                       Username, Realm, Nonce, XORRelayedAddress,
-                                      Lifetime, ErrorCode}
+                                      Lifetime, ErrorCode, XORPeerAddress}
 
   @moduletag :now
 
@@ -594,6 +594,133 @@ defmodule Jerboa.Client.ProtocolTest do
 
       assert {:ok, new_state} = Protocol.eval_refresh_resp(state)
       assert new_state.lifetime == duration
+    end
+  end
+
+  test "create_perm_req/2 returns encoded refresh request" do
+    peer_addr = {0, 0, 0, 0}
+    username = "alice"
+    realm = "wonderland"
+    secret = "1234"
+    nonce = "abcd"
+    state = %Worker{username: username, realm: realm, secret: secret,
+                    nonce: nonce}
+
+    %{transaction: %{req: msg}} = state |> Protocol.create_perm_req(peer_addr)
+    params = msg |> Format.decode!(secret: secret)
+
+
+    assert Params.get_class(params) == :request
+    assert Params.get_method(params) == :create_permission
+    assert Params.get_attr(params, Realm) == %Realm{value: realm}
+    assert Params.get_attr(params, Username) == %Username{value: username}
+    assert Params.get_attr(params, Nonce) == %Nonce{value: nonce}
+    assert %XORPeerAddress{address: ^peer_addr} =
+      Params.get_attr(params, XORPeerAddress)
+  end
+
+  describe "eval_create_perm_resp/1" do
+    test "returns error when response method is invalid" do
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:binding)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username, realm: realm)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_create_perm_resp(state)
+    end
+
+    test "returns error on failure response without error code" do
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:create_permission)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username, realm: realm)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_create_perm_resp(state)
+    end
+
+    test "returns error on response with invalid transaction id" do
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:refresh)
+      t_id = Params.generate_id()
+
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {{:error, :bad_response}, _} = Protocol.eval_create_perm_resp(state)
+    end
+
+    test "returns :retry if error reason is :stale_nonce" do
+      realm = "wonderland"
+      old_nonce = "dcba"
+      new_nonce = "abcd"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:create_permission)
+        |> Params.put_attr(%Realm{value: realm})
+        |> Params.put_attr(%Nonce{value: new_nonce})
+        |> Params.put_attr(%ErrorCode{name: :stale_nonce})
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, nonce: old_nonce}
+
+      assert {:retry, new_state} = Protocol.eval_create_perm_resp(state)
+      assert new_state.nonce == new_nonce
+    end
+
+    test "returns error if error reason is different than :stale_nonce" do
+      error = :try_alternate
+      resp_params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:create_permission)
+        |> Params.put_attr(%ErrorCode{name: error})
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}}
+
+      assert {{:error, ^error}, _} = Protocol.eval_create_perm_resp(state)
+    end
+
+    test "returns :ok on valid create permission response" do
+      username = "alice"
+      realm = "wonderland"
+      secret = "1234"
+      resp_params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:create_permission)
+      t_id = resp_params.identifier
+
+      resp = Format.encode(resp_params, secret: secret, username: username, realm: realm)
+      state = %Worker{transaction: %Transaction{id: t_id, resp: resp}, username: username,
+                      realm: realm, secret: secret}
+
+      assert {:ok, _} = Protocol.eval_create_perm_resp(state)
     end
   end
 end

--- a/test/jerboa/format/body/attribute/xor_address_test.exs
+++ b/test/jerboa/format/body/attribute/xor_address_test.exs
@@ -91,7 +91,31 @@ defmodule Jerboa.Format.Body.Attribute.XORAddressTest do
     end
   end
 
-  describe "XORMappedAddress.encode/2" do
+  describe "new/2" do
+    test "fills IPv4 family given address and port" do
+      address = {0, 0, 0, 0}
+      port = 1234
+
+      attr = XORMappedAddress.new(address, port)
+
+      assert attr.family == :ipv4
+      assert attr.address == address
+      assert attr.port == port
+    end
+
+    test "fills IPv6 family given address and port" do
+      address = {0, 0, 0, 0, 0, 0, 0, 0}
+      port = 1234
+
+      attr = XORMappedAddress.new(address, port)
+
+      assert attr.family == :ipv4
+      assert attr.address == address
+      assert attr.port == port
+    end
+  end
+
+  describe "XORAddress.encode/2" do
 
     test "IPv4" do
       attr = XORMAHelper.struct(4)

--- a/test/jerboa/format/body/attribute/xor_address_test.exs
+++ b/test/jerboa/format/body/attribute/xor_address_test.exs
@@ -109,7 +109,7 @@ defmodule Jerboa.Format.Body.Attribute.XORAddressTest do
 
       attr = XORMappedAddress.new(address, port)
 
-      assert attr.family == :ipv4
+      assert attr.family == :ipv6
       assert attr.address == address
       assert attr.port == port
     end

--- a/test/jerboa/format/body/attribute_test.exs
+++ b/test/jerboa/format/body/attribute_test.exs
@@ -279,7 +279,6 @@ defmodule Jerboa.Format.Body.AttributeTest do
       assert {:ok, _, ^attr} = Attribute.decode(meta, 0x001A, value(bin))
     end
 
-
     test "EVEN-PORT" do
       attr = %EvenPort{}
       meta = %Meta{}


### PR DESCRIPTION
Addresses #76 

Added one method to `Jerboa.Client`: `create_permission`. It issues CreatePermission request to the server, which creates permission or refreshes existing one.