### PR TITLE
Allow installing multiple permissions in one call to `Client.create_permission`

### DIFF
--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -121,20 +121,24 @@ defmodule Jerboa.Client do
   end
 
   @doc """
-  Creates permission on the allocation for the given peer
-  address
+  Creates permissions on the allocation for the given peer
+  addresses
 
   If permission is already installed for the given address,
   the permission will be refreshed.
 
-  ## Example
+  ## Examples
 
-      iex> create_permission client, {192, 168, 22, 111}
+      create_permission client, {192, 168, 22, 111}
+
+      create_permission client, [{192, 168, 22, 111}, {212, 168, 33, 222}]
   """
-  @spec create_permission(t, peer :: ip) :: :ok | {:error, error}
-  def create_permission(client, peer) do
-    GenServer.call(client, {:create_permission, peer})
+  @spec create_permission(t, peers :: ip | [ip, ...]) :: :ok | {:error, error}
+  def create_permission(_client, []), do: :ok
+  def create_permission(client, peers) when is_list(peers) do
+    GenServer.call(client, {:create_permission, peers})
   end
+  def create_permission(client, peer), do: create_permission(client, [peer])
 
   @doc """
   Stops the client

--- a/lib/jerboa/client/protocol.ex
+++ b/lib/jerboa/client/protocol.ex
@@ -121,11 +121,11 @@ defmodule Jerboa.Client.Protocol do
     end
   end
 
-  @spec create_perm_req(Worker.state, peer_addr :: Client.ip)
+  @spec create_perm_req(Worker.state, peer_addrs :: [Client.ip, ...])
     :: Worker.state
-  def create_perm_req(state, peer_addr) do
+  def create_perm_req(state, peer_addrs) do
     Logger.debug fn -> "Sending create permission request to the server" end
-    params = create_perm_params(state, peer_addr)
+    params = create_perm_params(state, peer_addrs)
     encode_request(params, state)
   end
 
@@ -322,15 +322,16 @@ defmodule Jerboa.Client.Protocol do
     end
   end
 
-  @spec create_perm_params(Worker.state, Client.ip) :: Params.t
-  defp create_perm_params(state, peer_addr) do
+  @spec create_perm_params(Worker.state, [Client.ip, ...]) :: Params.t
+  defp create_perm_params(state, peer_addrs) do
+    xor_peer_addrs = Enum.map peer_addrs, fn addr -> XPA.new(addr, 0) end
     Params.new()
     |> Params.put_class(:request)
     |> Params.put_method(:create_permission)
     |> Params.put_attr(%Username{value: state.username})
     |> Params.put_attr(%Realm{value: state.realm})
     |> Params.put_attr(%Nonce{value: state.nonce})
-    |> Params.put_attr(XPA.new(peer_addr, 0))
+    |> Params.put_attrs(xor_peer_addrs)
   end
 
   @spec handle_create_perm_resp(Worker.state)


### PR DESCRIPTION
Now it is possible to create multiple permissions with one request (as RFC allows).

Example:
```elixir
Jerboa.Client.create_permission client, [{192, 168, 2, 1}, {212, 1, 1, 1}]
```