### PR TITLE
Add CHANNEL-NUMBER TURN attribute

### DIFF
--- a/lib/jerboa/format/body/attribute/channel_number.ex
+++ b/lib/jerboa/format/body/attribute/channel_number.ex
@@ -1,0 +1,66 @@
+defmodule Jerboa.Format.Body.Attribute.ChannelNumber do
+  @moduledoc """
+  CHANNEL-NUMBER attribute as defined in [TURN RFC](https://trac.tools.ietf.org/html/rfc5766#section-14.1)
+  """
+
+  alias Jerboa.Format.ChannelNumber.First2BitsError
+  alias Jerboa.Format.Body.Attribute.{Decoder,Encoder}
+  alias Jerboa.Format.Meta
+
+  @min_number 0x4000
+  @max_number 0x7FFF
+
+  defstruct [:number]
+
+  @typedoc """
+  Contains the number of the channel
+  """
+  @type t :: %__MODULE__{
+    number: integer
+  }
+
+  defimpl Encoder do
+    alias Jerboa.Format.Body.Attribute.ChannelNumber
+    @type_code 0x000C
+
+    @spec type_code(ChannelNumber.t) :: integer
+    def type_code(_), do: @type_code
+
+    @spec encode(ChannelNumber.t, Meta.t) :: {Meta.t, binary}
+    def encode(attr, meta), do: {meta, ChannelNumber.encode(attr)}
+  end
+
+  defimpl Decoder do
+    alias Jerboa.Format.Body.Attribute.ChannelNumber
+
+    @spec decode(ChannelNumber.t, value :: binary, meta :: Meta.t)
+      :: {:ok, Meta.t, ChannelNumber.t} | {:error, struct}
+    def decode(_, value, meta), do: ChannelNumber.decode(value, meta)
+  end
+
+  @doc false
+  @spec encode(t) :: binary
+  def encode(%__MODULE__{number: n}) when is_integer(n) and (n in @min_number..@max_number) do
+    reserved = 0
+    <<n :: size(16), reserved :: size(16)>>
+  end
+
+  @doc false
+  @spec decode(binary, Meta.t) :: {:ok, Meta.t, t} | {:error, struct}
+  def decode(<<number :: size(16)-bits, _reserved :: size(16)>>, meta) do
+    case number do
+      <<0b01 :: size(2), _ :: size(14)>> ->
+        <<as_integer :: size(16)>> = number
+        {:ok, meta, %__MODULE__{number: as_integer}}
+      <<b :: 2-bits, _ :: 14>> ->
+        {:error, First2BitsError.exception(bits: b)}
+    end
+  end
+
+  @doc false
+  def min_number, do: @min_number
+
+  @doc false
+  def max_number, do: @max_number
+
+end

--- a/lib/jerboa/format/body/attribute/channel_number.ex
+++ b/lib/jerboa/format/body/attribute/channel_number.ex
@@ -4,7 +4,7 @@ defmodule Jerboa.Format.Body.Attribute.ChannelNumber do
   """
 
   alias Jerboa.Format.ChannelNumber.First2BitsError
-  alias Jerboa.Format.Body.Attribute.{Decoder,Encoder}
+  alias Jerboa.Format.Body.Attribute.{Decoder, Encoder}
   alias Jerboa.Format.Meta
 
   @min_number 0x4000

--- a/lib/jerboa/format/exceptions.ex
+++ b/lib/jerboa/format/exceptions.ex
@@ -514,3 +514,23 @@ defmodule Jerboa.Format.ReservationToken.LengthError do
                   "length. Expected 8 bytes, found #{length}"}
   end
 end
+
+defmodule Jerboa.Format.ChannelNumber.First2BitsError do
+  @moduledoc """
+  Error indicating that the first two bits of a CHANNEL-NUMBER value
+  do not match the required 0b01 value
+
+  Exception struct fields:
+
+  * `:bits` - a 2 bit long bitstring with the value of first two bits
+    of a message
+  """
+
+  defexception [:message, :bits]
+
+  def exception(opts) do
+    %__MODULE__{bits: opts[:bits],
+                message: "the two most significant bits of a TURN " <>
+                         "CHANNEL-NUMBER must be 0b01"}
+  end
+end

--- a/test/jerboa/format/body/attribute/channel_number_test.exs
+++ b/test/jerboa/format/body/attribute/channel_number_test.exs
@@ -1,0 +1,75 @@
+defmodule Jerboa.Format.Body.Attribute.ChannelNumberTest do
+  use ExUnit.Case
+  use Quixir
+
+  alias Jerboa.Format.Body.Attribute.ChannelNumber
+  alias Jerboa.Format.Meta
+
+  describe "encode/1" do
+
+    test "CHANNEL-NUMBER attribute with a valid number" do
+      min = ChannelNumber.min_number()
+      max = ChannelNumber.max_number()
+      ptest number: int(min: min, max: max) do
+        assert <<number::16, 0::16>> == %ChannelNumber{number: number} |> ChannelNumber.encode()
+      end
+    end
+
+    test "CHANNEL-NUMBER with an invalid/reserved number" do
+      ## See TURN RFC for the invalid range:
+      ## - https://tools.ietf.org/html/rfc5766#section-11
+      ## - https://tools.ietf.org/html/rfc5766#section-14.1
+      ptest number: int(min: 0x0000, max: 0x3FFF) do
+        assert_raise FunctionClauseError, fn ->
+          %ChannelNumber{number: number} |> ChannelNumber.encode()
+        end
+      end
+      ptest number: int(min: 0x8000, max: 0xFFFF) do
+        assert_raise FunctionClauseError, fn ->
+          %ChannelNumber{number: number} |> ChannelNumber.encode()
+        end
+      end
+    end
+
+  end
+
+  describe "decode/2" do
+
+    test "accepts binaries starting with 0b01" do
+      ptest number: int(min: 0b0100_0000_0000_0000, max: 0b0111_1111_1111_1111) do
+        encoded = <<number::16, 0::16>>
+        assert {:ok, _, %ChannelNumber{number: number}} = ChannelNumber.decode(encoded, %Meta{})
+      end
+    end
+
+    test "rejects binaries starting with 0b00, 0b10, 0b11" do
+      ptest number: int(min: 0b0, max: 0b0011_1111_1111_1111) do
+        encoded = <<number::16, 0::16>>
+        assert {:error, _} = ChannelNumber.decode(encoded, %Meta{})
+      end
+      ptest number: int(min: 0b1000_0000_0000_0000, max: 0b1111_1111_1111_1111) do
+        encoded = <<number::16, 0::16>>
+        assert {:error, _} = ChannelNumber.decode(encoded, %Meta{})
+      end
+    end
+
+  end
+
+  describe "decode/encode composition" do
+
+    test "is an identity" do
+      min = ChannelNumber.min_number()
+      max = ChannelNumber.max_number()
+      ptest number: int(min: min, max: max) do
+        cn = %ChannelNumber{number: number}
+        {:ok, _, new_cn} =
+          cn
+          |> ChannelNumber.encode()
+          |> ChannelNumber.decode(%Meta{})
+        assert cn === new_cn
+      end
+    end
+
+  end
+
+end

--- a/test/jerboa/format/body/attribute/channel_number_test.exs
+++ b/test/jerboa/format/body/attribute/channel_number_test.exs
@@ -11,7 +11,8 @@ defmodule Jerboa.Format.Body.Attribute.ChannelNumberTest do
       min = ChannelNumber.min_number()
       max = ChannelNumber.max_number()
       ptest number: int(min: min, max: max) do
-        assert <<number::16, 0::16>> == %ChannelNumber{number: number} |> ChannelNumber.encode()
+        assert <<number::16, 0::16>> \
+          == %ChannelNumber{number: number} |> ChannelNumber.encode()
       end
     end
 
@@ -38,7 +39,8 @@ defmodule Jerboa.Format.Body.Attribute.ChannelNumberTest do
     test "accepts binaries starting with 0b01" do
       ptest number: int(min: 0b0100_0000_0000_0000, max: 0b0111_1111_1111_1111) do
         encoded = <<number::16, 0::16>>
-        assert {:ok, _, %ChannelNumber{number: number}} = ChannelNumber.decode(encoded, %Meta{})
+        assert {:ok, _, %ChannelNumber{number: number}} \
+          = ChannelNumber.decode(encoded, %Meta{})
       end
     end
 


### PR DESCRIPTION
The attribute is needed for Fennec's datagram relay over channels: esl/fennec#18.