### PR TITLE
Receiving data coming over relay

### DIFF
--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -196,6 +196,33 @@ defmodule Jerboa.Client do
   end
 
   @doc """
+  Blocks the calling process until it receives the data from the given
+  peer
+
+  Calling process needs to be subscribed to this peer's data
+  before calling this function, otherwise it will always time out.
+
+  Accepts timeout in milliseconds as optional argument (defualt is 5000),
+  may be also atom `:infinity`.
+
+  This function simply uses subscriptions mechanism.
+  It implies lack of knowledge about permissions installed for the given
+  peer, thus if there is no permission, the function will most likely
+  time out.
+  """
+  @spec recv(t, peer_addr :: Client.ip)
+  :: {:ok, peer :: Client.address, data :: binary} | {:error, :timeout}
+  def recv(client, peer_addr, timeout \\ 5_000) do
+    receive do
+      {:peer_data, {^peer_addr, _} = peer, data} ->
+        {:ok, peer, data}
+    after
+      timeout ->
+        {:error, :timeout}
+    end
+  end
+
+  @doc """
   Stops the client
   """
   @spec stop(t) :: :ok | {:error, error}

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -161,7 +161,7 @@ defmodule Jerboa.Client do
   Subscribes PID to data received from the given peer
 
   Message format is
-      {:peer_data, client_pid :: pid,peer :: address, data :: binary}
+      {:peer_data, client_pid :: pid, peer :: address, data :: binary}
   """
   @spec subscribe(t, sub :: pid, peer_addr :: ip) :: :ok
   def subscribe(client, pid, peer_addr) do
@@ -172,7 +172,7 @@ defmodule Jerboa.Client do
   Subscribes calling process to data received from the given peer
 
   Message format is
-      {:peer_data, client_pid :: pid,peer :: address, data :: binary}
+      {:peer_data, client_pid :: pid, peer :: address, data :: binary}
   """
   @spec subscribe(t, peer_addr :: ip) :: :ok
   def subscribe(client, peer_addr) do

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -161,7 +161,7 @@ defmodule Jerboa.Client do
   Subscribes PID to data received from the given peer
 
   Message format is
-      {:peer_data, peer :: address, data :: binary}
+      {:peer_data, client_pid :: pid,peer :: address, data :: binary}
   """
   @spec subscribe(t, sub :: pid, peer_addr :: ip) :: :ok
   def subscribe(client, pid, peer_addr) do
@@ -172,7 +172,7 @@ defmodule Jerboa.Client do
   Subscribes calling process to data received from the given peer
 
   Message format is
-      {:peer_data, peer :: address, data :: binary}
+      {:peer_data, client_pid :: pid,peer :: address, data :: binary}
   """
   @spec subscribe(t, peer_addr :: ip) :: :ok
   def subscribe(client, peer_addr) do
@@ -214,7 +214,7 @@ defmodule Jerboa.Client do
   :: {:ok, peer :: Client.address, data :: binary} | {:error, :timeout}
   def recv(client, peer_addr, timeout \\ 5_000) do
     receive do
-      {:peer_data, {^peer_addr, _} = peer, data} ->
+      {:peer_data, ^client, {^peer_addr, _} = peer, data} ->
         {:ok, peer, data}
     after
       timeout ->

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -155,6 +155,44 @@ defmodule Jerboa.Client do
     :: :ok | {:error, :no_permission}
   def send(client, peer, data) do
     request(client, {:send, peer, data}).()
+    end
+
+  @doc """
+  Subscribes PID to data received from the given peer
+
+  Message format is
+      {:peer_data, peer :: address, data :: binary}
+  """
+  @spec subscribe(t, sub :: pid, peer_addr :: ip) :: :ok
+  def subscribe(client, pid, peer_addr) do
+    request(client, {:subscribe, pid, peer_addr}).()
+  end
+
+  @doc """
+  Subscribes calling process to data received from the given peer
+
+  Message format is
+      {:peer_data, peer :: address, data :: binary}
+  """
+  @spec subscribe(t, peer_addr :: ip) :: :ok
+  def subscribe(client, peer_addr) do
+    subscribe(client, self(), peer_addr)
+  end
+
+  @doc """
+  Cancels subscription of given PID
+  """
+  @spec unsubscribe(t, sub :: pid, peer_addr :: ip) :: :ok
+  def unsubscribe(client, pid, peer_addr) do
+    request(client, {:unsubscribe, pid, peer_addr}).()
+  end
+
+  @doc """
+  Cancels subscription of calling process
+  """
+  @spec unsubscribe(t, peer_addr :: ip) :: :ok
+  def unsubscribe(client, peer_addr) do
+    unsubscribe(client, self(), peer_addr)
   end
 
   @doc """

--- a/lib/jerboa/client/protocol/data.ex
+++ b/lib/jerboa/client/protocol/data.ex
@@ -1,0 +1,21 @@
+defmodule Jerboa.Client.Protocol.Data do
+  @moduledoc false
+
+  alias Jerboa.Params
+  alias Jerboa.Format.Body.Attribute.XORPeerAddress, as: XPA
+  alias Jerboa.Format.Body.Attribute.Data
+  alias Jerboa.Client
+
+  @spec eval_indication(Params.t)
+    :: {:ok, peer :: Client.address, binary} | :error
+  def eval_indication(params) do
+    with :indication <- Params.get_class(params),
+         :data <- Params.get_method(params),
+         %Data{content: data} <- Params.get_attr(params, Data),
+         %XPA{address: addr, port: port} <- Params.get_attr(params, XPA) do
+      {:ok, {addr, port}, data}
+    else
+      _ -> :error
+    end
+  end
+end

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -401,9 +401,11 @@ defmodule Jerboa.Client.Worker do
 
   @spec update_subscriber_ref(subscribers, pid, reference) :: subscribers
   defp update_subscriber_ref(subscribers, sub_pid, sub_ref) do
-    if Map.has_key?(subscribers, sub_pid) do
-      old_ref = Map.get(subscribers, sub_pid)
-      Process.demonitor(old_ref)
+    case Map.fetch(subscribers, sub_pid) do
+      {:ok, old_ref} ->
+        Process.demonitor(old_ref)
+      _ ->
+        :ok
     end
     Map.put(subscribers, sub_pid, sub_ref)
   end

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -11,7 +11,7 @@ defmodule Jerboa.Client.Worker do
   alias Jerboa.Client.Relay.Permission
   alias Jerboa.Client.Protocol
   alias Jerboa.Client.Protocol.{Binding, Allocate, Refresh,
-                                CreatePermission, Send}
+                                CreatePermission, Send, Data}
   alias Jerboa.Client.Transaction
 
   require Logger

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -230,7 +230,7 @@ defmodule Jerboa.Client.Worker do
     state.subscriptions
     |> Map.get(peer_addr, [])
     |> Enum.each(fn {sub_pid, _} ->
-      send sub_pid, {:peer_data, peer, data}
+      send sub_pid, {:peer_data, self(), peer, data}
     end)
   end
 

--- a/test/jerboa/client/protocol/create_permission_test.exs
+++ b/test/jerboa/client/protocol/create_permission_test.exs
@@ -9,8 +9,6 @@ defmodule Jerboa.Client.Protocol.CreatePermissionTest do
   alias Jerboa.Format.Body.Attribute.XORPeerAddress, as: XPA
   alias Jerboa.Format.Body.Attribute.{Nonce, ErrorCode}
 
-  @moduletag :now
-
   test "request/2 returns valid create permission request signed with creds" do
     creds = CH.final()
     peer_addr1 = {127, 0, 0, 1}
@@ -32,7 +30,7 @@ defmodule Jerboa.Client.Protocol.CreatePermissionTest do
     assert peer_addr2 in xor_peer_addrs
   end
 
-    describe "eval_response/2" do
+  describe "eval_response/2" do
     test "returns :ok on successful refresh response" do
       creds = CH.final()
 

--- a/test/jerboa/client/protocol/data_test.exs
+++ b/test/jerboa/client/protocol/data_test.exs
@@ -1,0 +1,75 @@
+defmodule Jerboa.Client.Protocol.DataTest do
+  use ExUnit.Case
+
+  alias Jerboa.Params
+  alias Jerboa.Client.Protocol.Data
+  alias Jerboa.Format.Body.Attribute.Data, as: DataAttr
+  alias Jerboa.Format.Body.Attribute.XORPeerAddress, as: XPA
+
+  describe "eval_indication/1" do
+    test "returns peer address and data given valid data indication" do
+      data = "alicehasacat"
+      peer_addr = {127, 0, 0, 1}
+      peer_port = 33_333
+      params =
+        Params.new()
+        |> Params.put_class(:indication)
+        |> Params.put_method(:data)
+        |> Params.put_attr(%DataAttr{content: data})
+        |> Params.put_attr(XPA.new(peer_addr, peer_port))
+
+      assert {:ok, {peer_addr, peer_port}, data} == Data.eval_indication(params)
+    end
+
+    test "returns :error on invalid STUN class" do
+      data = "alicehasacat"
+      peer_addr = {127, 0, 0, 1}
+      peer_port = 33_333
+      params =
+        Params.new()
+        |> Params.put_class(:request)
+        |> Params.put_method(:data)
+        |> Params.put_attr(%DataAttr{content: data})
+        |> Params.put_attr(XPA.new(peer_addr, peer_port))
+
+      assert :error == Data.eval_indication(params)
+    end
+
+    test "returns :error on invalid STUN method" do
+      data = "alicehasacat"
+      peer_addr = {127, 0, 0, 1}
+      peer_port = 33_333
+      params =
+        Params.new()
+        |> Params.put_class(:indication)
+        |> Params.put_method(:allocate)
+        |> Params.put_attr(%DataAttr{content: data})
+        |> Params.put_attr(XPA.new(peer_addr, peer_port))
+
+      assert :error == Data.eval_indication(params)
+    end
+
+    test "returns :error without DATA attribute" do
+      peer_addr = {127, 0, 0, 1}
+      peer_port = 33_333
+      params =
+        Params.new()
+        |> Params.put_class(:indication)
+        |> Params.put_method(:data)
+        |> Params.put_attr(XPA.new(peer_addr, peer_port))
+
+      assert :error == Data.eval_indication(params)
+    end
+
+    test "returns :error without XOR-PEER-ADDRESS attribute" do
+      data = "alicehasacat"
+      params =
+        Params.new()
+        |> Params.put_class(:indication)
+        |> Params.put_method(:data)
+        |> Params.put_attr(%DataAttr{content: data})
+
+      assert :error == Data.eval_indication(params)
+    end
+  end
+end


### PR DESCRIPTION
This PR is an alternative implementation of #95.

Instead of installing handler functions in the client process, processes can subscribe to data sent by specified peers. This way we have even more generic behaviour plus we can easily track subscribers and clean up state related to them when they die.