### PR TITLE
Allow :unknown protocol value in RequestedTransport struct

### DIFF
--- a/lib/jerboa/format/body/attribute/requested_transport.ex
+++ b/lib/jerboa/format/body/attribute/requested_transport.ex
@@ -5,19 +5,20 @@ defmodule Jerboa.Format.Body.Attribute.RequestedTransport do
   """
 
   alias Jerboa.Format.Body.Attribute.{Encoder, Decoder}
-  alias Jerboa.Format.RequestedTransport.{ProtocolError,
-                                          LengthError}
+  alias Jerboa.Format.RequestedTransport.LengthError
   alias Jerboa.Format.Meta
 
   defstruct protocol: :udp
 
-  @type protocol :: :udp
+  @type protocol :: :udp | :unknown
   @type protocol_code :: 17
 
   @typedoc """
   Represents transport requested for allocation
 
-  Currently only `:udp` is a valid value.
+  Currently only `:udp` is a valid protocol value. This struct may also hold
+  atom `:unknown` which means that Jerboa does not know given protocol number,
+  but the attribute is formatteed correctly.
   """
   @type t :: %__MODULE__{
     protocol: protocol
@@ -56,7 +57,7 @@ defmodule Jerboa.Format.Body.Attribute.RequestedTransport do
   def decode(<<proto_code::8, _::24>>, meta) do
     case code_to_proto(proto_code) do
       :error ->
-        {:error, ProtocolError.exception(protocol_code: proto_code)}
+        {:ok, meta, %__MODULE__{protocol: :unknown}}
       proto ->
         {:ok, meta, %__MODULE__{protocol: proto}}
     end

--- a/lib/jerboa/format/exceptions.ex
+++ b/lib/jerboa/format/exceptions.ex
@@ -411,29 +411,6 @@ defmodule Jerboa.Format.ErrorCode.LengthError do
   end
 end
 
-defmodule Jerboa.Format.RequestedTransport.ProtocolError do
-  @moduledoc """
-  Error indicating that protocol code found in REQUESTED-TRANSPORT
-  attribute is invalid
-
-  Jerboa currently supports only UDP transport (code 17), so any
-  other value results in this error. The list of available protocols
-  will be extended when TURN extensions will be implemented.
-
-  Exception struct fields:
-  * `:protocol_code` - protocol code found in STUN message
-  """
-
-  defexception [:message, :protocol_code]
-
-  def exception(opts) do
-    proto = opts[:protocol_code]
-    %__MODULE__{protocol_code: proto,
-                message: "Unknown protocol code found in " <>
-                  "REQUESTED-TRANSPORT attribute: #{proto}"}
-  end
-end
-
 defmodule Jerboa.Format.RequestedTransport.LengthError do
   @moduledoc """
   Error indicating that REQUESTED-TRANSPORT attribute's value

--- a/test/jerboa/format/body/attribute/requested_transport_test.exs
+++ b/test/jerboa/format/body/attribute/requested_transport_test.exs
@@ -21,7 +21,7 @@ defmodule Jerboa.Format.Body.Attribute.RequestedTransportTest do
       proto_code = 1
       value = <<proto_code::8, 0::24>>
 
-      assert {:error, %ProtocolError{protocol_code: ^proto_code}} =
+      assert {:ok, _, %RequestedTransport{protocol: :unknown}} =
         RequestedTransport.decode(value, %Meta{})
     end
 


### PR DESCRIPTION
TURN servers need to decode REQUESTED-TRANSPORT attribute if it is formatted correctly, and then check if the protocol is supported. Previously there was no way to achieve that, since unknown protocol resulted in decoding failure.

Addresses #72