### PR TITLE
Add ReservationToken.new/0

### DIFF
--- a/lib/jerboa/format/body/attribute/reservation_token.ex
+++ b/lib/jerboa/format/body/attribute/reservation_token.ex
@@ -19,6 +19,13 @@ defmodule Jerboa.Format.Body.Attribute.ReservationToken do
     value: binary
   }
 
+  @doc """
+  Create a new reservation token with a random value
+  """
+  def new do
+    %__MODULE__{value: :crypto.strong_rand_bytes(@byte_length)}
+  end
+
   defimpl Encoder do
     alias Jerboa.Format.Body.Attribute.ReservationToken
     @type_code 0x0022


### PR DESCRIPTION
The token size is strictly defined, but it's not exported from the module for outside use. Moreover, passing a value of a wrong size will not error on creation, but on encoding, which is quite late. Having a constructor can solve both of these and make external usage more convenient.