### PR TITLE
Narrow `Client.ip` type to IPv4 IPs

### DIFF
--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -53,7 +53,7 @@ defmodule Jerboa.Client do
 
   @type t :: pid
   @type port_no :: :inet.port_number
-  @type ip :: :inet.ip_address
+  @type ip :: :inet.ip4_address
   @type address :: {ip, port_no}
   @type start_opts :: [start_opt]
   @type start_opt :: {:server, address}


### PR DESCRIPTION
Base TURN RFC requires that we work on IPv4 addresses only. Unfortunately there might be the case when someone would like to send Binding request only, which is not restricted to IPv4. However we can't know that before starting the client, so it's safer to narrow down the spec to IPv4.

Partially addresses #95.