### PR TITLE
Even port and reservations

### DIFF
--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -60,7 +60,9 @@ defmodule Jerboa.Client do
                    | {:username, String.t}
                    | {:secret, String.t}
   @type allocate_opts :: [allocate_opt]
-  @type allocate_opt :: {:even_port, boolean} | {:reserve, boolean}
+  @type allocate_opt :: {:even_port, boolean}
+                      | {:reserve, boolean}
+                      | {:reservation_token, <<_::64>>}
   @type error :: :bad_response
                | :no_allocation
                | Jerboa.Format.Body.Attribute.ErrorCode.name
@@ -116,7 +118,13 @@ defmodule Jerboa.Client do
     allocate even port number
   * `:reserve` - optional - if set to `true`, prompts the server to allocate
     an even port, reserve next highest port number, and return a reservation
-    token which can be later used to create an allocation on reserved port
+    token which can be later used to create an allocation on reserved port.
+    If this option is present, `:even_port` is ignored.
+  * `:reservation_token` - optional - token returned by previous allocation
+    request with `reserve: true`. Passing the token should result in reserved
+    port being assigned to the allocation, or an error if the token is invalid
+    or the reservation has timed out. If this option is present, `:reserve`
+    is ignored.
   """
   @spec allocate(t) :: {:ok, address} | {:error, error}
   @spec allocate(t, allocate_opts) :: {:ok, address} | {:error, error}

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -60,7 +60,7 @@ defmodule Jerboa.Client do
                    | {:username, String.t}
                    | {:secret, String.t}
   @type allocate_opts :: [allocate_opt]
-  @type allocate_opt :: {:even_port, boolean}
+  @type allocate_opt :: {:even_port, boolean} | {:reserve, boolean}
   @type error :: :bad_response
                | :no_allocation
                | Jerboa.Format.Body.Attribute.ErrorCode.name
@@ -114,6 +114,9 @@ defmodule Jerboa.Client do
   * `:even_port` - optional - if set to `true`, EVEN-PORT attribute
     will be included in the request, which prompts the server to
     allocate even port number
+  * `:reserve` - optional - if set to `true`, prompts the server to allocate
+    an even port, reserve next highest port number, and return a reservation
+    token which can be later used to create an allocation on reserved port
   """
   @spec allocate(t) :: {:ok, address} | {:error, error}
   @spec allocate(t, allocate_opts) :: {:ok, address} | {:error, error}

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -59,6 +59,8 @@ defmodule Jerboa.Client do
   @type start_opt :: {:server, address}
                    | {:username, String.t}
                    | {:secret, String.t}
+  @type allocate_opts :: [allocate_opt]
+  @type allocate_opt :: {:even_port, boolean}
   @type error :: :bad_response
                | :no_allocation
                | Jerboa.Format.Body.Attribute.ErrorCode.name
@@ -106,10 +108,17 @@ defmodule Jerboa.Client do
   @doc """
   Creates allocation on the server or returns relayed transport
   address if client already has an allocation
+
+  ## Options
+
+  * `:even_port` - optional - if set to `true`, EVEN-PORT attribute
+    will be included in the request, which prompts the server to
+    allocate even port number
   """
   @spec allocate(t) :: {:ok, address} | {:error, error}
-  def allocate(client) do
-    call = request(client, :allocate)
+  @spec allocate(t, allocate_opts) :: {:ok, address} | {:error, error}
+  def allocate(client, opts \\ []) do
+    call = request(client, {:allocate, opts})
     case call.() do
       {:error, :stale_nonce} -> call.()
       {:error, :unauthorized} -> call.()

--- a/lib/jerboa/client/protocol/allocate.ex
+++ b/lib/jerboa/client/protocol/allocate.ex
@@ -5,14 +5,14 @@ defmodule Jerboa.Client.Protocol.Allocate do
   alias Jerboa.Format.Body.Attribute.XORMappedAddress, as: XMA
   alias Jerboa.Format.Body.Attribute.XORRelayedAddress, as: XRA
   alias Jerboa.Format.Body.Attribute.{RequestedTransport, Lifetime, Realm,
-                                      Nonce, ErrorCode}
+                                      Nonce, ErrorCode, EvenPort}
   alias Jerboa.Client
   alias Jerboa.Client.Protocol
   alias Jerboa.Client.Credentials
 
-  @spec request(Credentials.t) :: Protocol.request
-  def request(creds) do
-    params = params(creds)
+  @spec request(Credentials.t, Client.allocate_opts) :: Protocol.request
+  def request(creds, opts) do
+    params = params(creds, opts)
     Protocol.encode_request(params, creds)
   end
 
@@ -35,13 +35,19 @@ defmodule Jerboa.Client.Protocol.Allocate do
     end
   end
 
-  @spec params(Credentials.t) :: Params.t
-  defp params(creds) do
-    creds
-    |> Protocol.base_params()
-    |> Params.put_class(:request)
-    |> Params.put_method(:allocate)
-    |> Params.put_attr(%RequestedTransport{})
+  @spec params(Credentials.t, Client.allocate_opts) :: Params.t
+  defp params(creds, opts) do
+    params =
+      creds
+      |> Protocol.base_params()
+      |> Params.put_class(:request)
+      |> Params.put_method(:allocate)
+      |> Params.put_attr(%RequestedTransport{})
+    if opts[:even_port] do
+      params |> Params.put_attr(%EvenPort{reserved?: false})
+    else
+      params
+    end
   end
 
   @spec eval_failure(resp :: Params.t, Credentials.t)

--- a/lib/jerboa/client/protocol/allocate.ex
+++ b/lib/jerboa/client/protocol/allocate.ex
@@ -76,6 +76,9 @@ defmodule Jerboa.Client.Protocol.Allocate do
       |> Params.put_method(:allocate)
       |> Params.put_attr(%RequestedTransport{})
     cond do
+      opts[:reservation_token] ->
+        token = opts[:reservation_token]
+        params |> Params.put_attr(%ReservationToken{value: token})
       opts[:reserve] == true ->
         params |> Params.put_attr(%EvenPort{reserved?: true})
       opts[:even_port] == true ->

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -61,13 +61,13 @@ defmodule Jerboa.Client.Worker do
     transaction = Transaction.new(from, id, binding_response_handler())
     {:noreply, add_transaction(state, transaction)}
   end
-  def handle_call(:allocate, from, state) do
+  def handle_call({:allocate, opts}, from, state) do
     if state.relay.address do
       _ = Logger.debug "Allocation already present on the server, " <>
         "allocate request blocked"
       {:reply, {:ok, state.relay.address}, state}
     else
-      {id, request} = Allocate.request(state.credentials)
+      {id, request} = Allocate.request(state.credentials, opts)
       _ = Logger.debug "Sending allocate request to the server"
       send(request, state.server, state.socket)
       transaction = Transaction.new(from, id, allocate_response_handler())

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -184,7 +184,7 @@ defmodule Jerboa.Client.Worker do
     %{state | credentials: creds, relay: relay}
   end
 
-  @spec setup_logger_metadata(UDP.socket, Client.address) :: any
+  @spec setup_logger_metadata(UDP.socket, Client.address) :: :ok
   defp setup_logger_metadata(socket, server) do
     {:ok, port} = :inet.port(socket)
     metadata = [jerboa_client: "#{inspect self()}:#{port}",

--- a/test/jerboa/client/protocol/allocate_test.exs
+++ b/test/jerboa/client/protocol/allocate_test.exs
@@ -63,6 +63,25 @@ defmodule Jerboa.Client.Protocol.AllocateTest do
       assert PH.realm(params) == creds.realm
       assert PH.nonce(params) == creds.nonce
     end
+
+    test "returns valid allocate request with RESERVATION-TOKEN attribute" do
+      creds = CH.final()
+      token = <<0::8*8>> # token must be 8 bytes long
+
+      {id, request} = Allocate.request(creds, reservation_token: token)
+      params = Protocol.decode!(request, creds)
+
+      assert params.identifier == id
+      assert params.class == :request
+      assert params.method == :allocate
+      assert params.signed?
+      assert params.verified?
+      assert %ReservationToken{value: token} ==
+        Params.get_attr(params, ReservationToken)
+      assert PH.username(params) == creds.username
+      assert PH.realm(params) == creds.realm
+      assert PH.nonce(params) == creds.nonce
+    end
   end
 
   describe "eval_response/2" do

--- a/test/jerboa/client/protocol/allocate_test.exs
+++ b/test/jerboa/client/protocol/allocate_test.exs
@@ -66,7 +66,7 @@ defmodule Jerboa.Client.Protocol.AllocateTest do
 
     test "returns valid allocate request with RESERVATION-TOKEN attribute" do
       creds = CH.final()
-      token = <<0::8*8>> # token must be 8 bytes long
+      token = <<0::8 * 8>> # token must be 8 bytes long
 
       {id, request} = Allocate.request(creds, reservation_token: token)
       params = Protocol.decode!(request, creds)


### PR DESCRIPTION
This PR adds support for three additional options which may be passed to `Client.allocate/2`:
* `even_port: true` which makes the client request even port without reservation
* `reserve: true` which makes the client request even port with reservation
* `reservation_token: <token>` which makes the client use previously obtained reservation token for the allocation

