### PR TITLE
Channels client

### DIFF
--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -279,6 +279,26 @@ defmodule Jerboa.Client do
   end
 
   @doc """
+  Opens or refreshes a channel between client and one of the peers
+
+  Once the channel is opened, all communication with the peer will be
+  done via channel. It results in more efficient communication, because
+  channels require smaller message headers than STUN messages.
+
+  To exchange data via channel, you can use the same `send`, `subscribe`, and
+  friends API as in the regular TURN communication.
+
+  Opening a channel automatically installs a permission for the given peer.
+  However, note that permissions are valid for 5 minutes after installation,
+  whereas channels are valid for 10 minutes. It is required to refresh
+  permissions more often than channels.
+  """
+  @spec open_channel(t, peer :: Client.address) :: :ok | {:error, error}
+  def open_channel(client, peer) do
+    request(client, {:open_channel, peer}).()
+  end
+
+  @doc """
   Stops the client
   """
   @spec stop(t) :: :ok | {:error, error}

--- a/lib/jerboa/client.ex
+++ b/lib/jerboa/client.ex
@@ -293,7 +293,9 @@ defmodule Jerboa.Client do
   whereas channels are valid for 10 minutes. It is required to refresh
   permissions more often than channels.
   """
-  @spec open_channel(t, peer :: Client.address) :: :ok | {:error, error}
+  @spec open_channel(t, peer :: Client.address)
+  :: :ok
+   | {:error, error | :peer_locked | :capacity_reached | :retries_limit_reached}
   def open_channel(client, peer) do
     request(client, {:open_channel, peer}).()
   end

--- a/lib/jerboa/client/protocol.ex
+++ b/lib/jerboa/client/protocol.ex
@@ -15,6 +15,12 @@ defmodule Jerboa.Client.Protocol do
 
   ## API
 
+  @spec encode_channel_data(Format.channel_number, binary) :: binary
+  def encode_channel_data(number, data) do
+    %ChannelData{channel_number: number, data: data}
+    |> Format.encode()
+  end
+
   @spec encode_request(Params.t, Credentials.t) :: request
   def encode_request(params, creds) do
     opts = Credentials.to_decode_opts(creds)

--- a/lib/jerboa/client/protocol.ex
+++ b/lib/jerboa/client/protocol.ex
@@ -4,6 +4,7 @@ defmodule Jerboa.Client.Protocol do
   alias Jerboa.Client
   alias Jerboa.Client.Credentials
   alias Jerboa.Params
+  alias Jerboa.ChannelData
   alias Jerboa.Format
   alias Jerboa.Format.Body.Attribute.{Username, Realm, Nonce, ErrorCode}
 
@@ -20,7 +21,8 @@ defmodule Jerboa.Client.Protocol do
     {params.identifier, Format.encode(params, opts)}
   end
 
-  @spec decode!(packet :: binary, Credentials.t) :: Params.t | no_return
+  @spec decode!(packet :: binary, Credentials.t)
+    :: Params.t | ChannelData.t | no_return
   def decode!(packet, creds) do
     opts = Credentials.to_decode_opts(creds)
     Format.decode!(packet, opts)

--- a/lib/jerboa/client/protocol/channel_bind.ex
+++ b/lib/jerboa/client/protocol/channel_bind.ex
@@ -1,0 +1,45 @@
+defmodule Jerboa.Client.Protocol.ChannelBind do
+  @moduledoc false
+
+  alias Jerboa.Params
+  alias Jerboa.Format.Body.Attribute.XORPeerAddress, as: XPA
+  alias Jerboa.Format.Body.Attribute.ChannelNumber
+
+  alias Jerboa.Client
+  alias Jerboa.Client.Credentials
+  alias Jerboa.Client.Protocol
+
+  @spec request(Credentials.t, peer :: Client.address,
+    Jerboa.Format.channel_number) :: Protocol.request
+  def request(creds, peer, channel_number) do
+    params = params(creds, peer, channel_number)
+    Protocol.encode_request(params, creds)
+  end
+
+  @spec eval_response(resp :: Params.t, Credentials.t)
+    :: :ok | {:error, Client.error, Credentials.t}
+  def eval_response(params, creds) do
+    with :channel_bind <- Params.get_method(params),
+         :success <- Params.get_class(params) do
+      :ok
+    else
+      :failure ->
+        Protocol.eval_failure(params, creds)
+      _ ->
+        {:error, :bad_response, creds}
+    end
+  end
+
+  ## Internals
+
+  @spec params(Credentials.t, Client.address, Jerboa.Format.channel_number)
+    :: Params.t
+  defp params(creds, {ip, port}, channel_number) do
+    creds
+    |> Protocol.base_params()
+    |> Params.put_class(:request)
+    |> Params.put_method(:channel_bind)
+    |> Params.put_attr(XPA.new(ip, port))
+    |> Params.put_attr(%ChannelNumber{number: channel_number})
+  end
+end

--- a/lib/jerboa/client/relay.ex
+++ b/lib/jerboa/client/relay.ex
@@ -42,7 +42,7 @@ defmodule Jerboa.Client.Relay do
     %__MODULE__{relay | permissions: permissions}
   end
 
-  @spec remove_permission(Relay.t, Client.ip) :: Relay.t
+  @spec remove_permission(t, Client.ip) :: t
   def remove_permission(relay, peer_addr) do
     permissions = Map.delete(relay.permissions, peer_addr)
     %__MODULE__{relay | permissions: permissions}
@@ -55,7 +55,7 @@ defmodule Jerboa.Client.Relay do
     end)
   end
 
-  @spec get_permission_timers(Relay.t) :: [timer_ref :: reference]
+  @spec get_permission_timers(t) :: [timer_ref :: reference]
   def get_permission_timers(relay) do
     relay.permissions
     |> Enum.map(fn {_, timer_ref} -> timer_ref end)
@@ -72,7 +72,7 @@ defmodule Jerboa.Client.Relay do
   end
 
   @spec remove_channel(t, peer :: Client.address, Format.channel_number)
-    :: Relay.t
+    :: t
   def remove_channel(relay, peer, channel_number) do
     by_peer = Map.delete(relay.channels.by_peer, peer)
     by_number = Map.delete(relay.channels.by_number, channel_number)

--- a/lib/jerboa/client/relay.ex
+++ b/lib/jerboa/client/relay.ex
@@ -9,11 +9,12 @@ defmodule Jerboa.Client.Relay do
   defstruct [:address, :lifetime, :timer_ref, permissions: %{},
              channels: {%{}, %{}}]
 
+  @type permissions :: %{Client.ip => timer_ref :: reference}
   @type t :: %__MODULE__{
     address:   nil | Client.address,
     lifetime:  nil | non_neg_integer,
     timer_ref: nil | reference,
-    permissions: %{Client.ip => timer_ref :: reference},
+    permissions: permissions,
 
     ## `:channels` is a tuple of two maps, which have the same values,
     ## but under different keys. The first one's keys are peer adresses
@@ -22,4 +23,88 @@ defmodule Jerboa.Client.Relay do
     channels: {%{peer :: Client.address => Channel.t},
                %{Format.channel_number  => Channel.t}}
   }
+
+  @spec active?(t) :: boolean
+  def active?(relay), do: relay.address != nil
+
+  @spec put_address(t, Client.address) :: t
+  def put_address(relay, address), do: %__MODULE__{relay | address: address}
+
+  @spec put_lifetime(t, lifetime :: non_neg_integer) :: t
+  def put_lifetime(relay, lifetime), do: %__MODULE__{relay | lifetime: lifetime}
+
+  @spec put_timer_ref(t, reference) :: t
+  def put_timer_ref(relay, timer_ref) do
+    %__MODULE__{relay | timer_ref: timer_ref}
+  end
+
+  @spec put_permissions(t, permissions) :: t
+  def put_permissions(relay, permissions) do
+    %__MODULE__{relay | permissions: permissions}
+  end
+
+  @spec remove_permission(Relay.t, Client.ip) :: Relay.t
+  def remove_permission(relay, peer_addr) do
+    permissions = Map.delete(relay.permissions, peer_addr)
+    %__MODULE__{relay | permissions: permissions}
+  end
+
+  @spec has_permission?(t, peer :: Client.address) :: boolean
+  def has_permission?(relay, {ip, _port}) do
+    Enum.any?(relay.permissions, fn {peer_addr, _} ->
+      peer_addr == ip
+    end)
+  end
+
+  @spec get_permission_timers(Relay.t) :: [timer_ref :: reference]
+  def get_permission_timers(relay) do
+    relay.permissions
+    |> Enum.map(fn {_, timer_ref} -> timer_ref end)
+  end
+
+  @spec put_channel(t, Channel.t, (Channel.t -> any)) :: t
+  def put_channel(relay, channel, on_update \\ fn _ -> :ok end) do
+    {peer_to_channel, number_to_channel} = relay.channels
+    channels =
+      {Map.update(peer_to_channel, channel.peer, channel, on_update),
+       Map.update(number_to_channel, channel.number,
+         channel, on_update)}
+    %__MODULE__{relay | channels: channels}
+  end
+
+  @spec remove_channel(t, peer :: Client.address, Format.channel_number)
+    :: Relay.t
+  def remove_channel(relay, peer, channel_number) do
+    {peer_to_channel, number_to_channel} = relay.channels
+    channels = {Map.delete(peer_to_channel, peer),
+                Map.delete(number_to_channel, channel_number)}
+    %__MODULE__{relay | channels: channels}
+  end
+
+  @spec get_channels(t) :: [Channel.t]
+  def get_channels(relay) do
+    {peer_to_channel, _} = relay.channels
+    Map.values(peer_to_channel)
+  end
+
+  @spec get_channel_by_peer(t, Client.address) :: {:ok, Channel.t} | :error
+  def get_channel_by_peer(relay, peer) do
+    {peer_to_channel, _} = relay.channels
+    Map.fetch(peer_to_channel, peer)
+  end
+
+  @spec get_channel_by_number(t, Format.channel_number)
+    :: {:ok, Channel.t} | :error
+  def get_channel_by_number(relay, number) do
+    {_, number_to_channel} = relay.channels
+    Map.fetch(number_to_channel, number)
+  end
+
+  @spec has_channel_bound?(t, Client.address) :: boolean
+  def has_channel_bound?(relay, peer) do
+    case get_channel_by_peer(relay, peer) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
 end

--- a/lib/jerboa/client/relay.ex
+++ b/lib/jerboa/client/relay.ex
@@ -3,13 +3,23 @@ defmodule Jerboa.Client.Relay do
   ## Data structure describing relay (allocation)
 
   alias Jerboa.Client
+  alias Jerboa.Client.Channel
+  alias Jerboa.Format
 
-  defstruct [:address, :lifetime, :timer_ref, permissions: %{}]
+  defstruct [:address, :lifetime, :timer_ref, permissions: %{},
+             channels: {%{}, %{}}]
 
   @type t :: %__MODULE__{
     address:   nil | Client.address,
     lifetime:  nil | non_neg_integer,
     timer_ref: nil | reference,
-    permissions: %{Client.ip => timer_ref :: reference}
+    permissions: %{Client.ip => timer_ref :: reference},
+
+    ## `:channels` is a tuple of two maps, which have the same values,
+    ## but under different keys. The first one's keys are peer adresses
+    ## bound to channels, the other one's keys are channel numbers of
+    ## those channels. The values in both are Channel structs.
+    channels: {%{peer :: Client.address => Channel.t},
+               %{Format.channel_number  => Channel.t}}
   }
 end

--- a/lib/jerboa/client/relay/channel.ex
+++ b/lib/jerboa/client/relay/channel.ex
@@ -1,0 +1,14 @@
+defmodule Jerboa.Client.Relay.Channel do
+  @moduledoc false
+
+  alias Jerboa.Client
+  alias Jerboa.Format
+
+  defstruct [:peer, :number, :timer_ref]
+
+  @type t :: %__MODULE__{
+    peer: Client.address,
+    number: Format.channel_number,
+    timer_ref: reference
+  }
+end

--- a/lib/jerboa/client/relay/channels.ex
+++ b/lib/jerboa/client/relay/channels.ex
@@ -6,11 +6,14 @@ defmodule Jerboa.Client.Relay.Channels do
   alias Jerboa.Format
 
   defstruct locked_peers: MapSet.new(), locked_numbers: MapSet.new(),
-    by_peer: %{}, by_number: %{}
+    lock_timer_refs: %{}, by_peer: %{}, by_number: %{}
 
   @type t :: %__MODULE__{
     locked_peers: MapSet.t(peer :: Client.address),
     locked_numbers: MapSet.t(Format.channel_number),
+    ## since we always atomically lock both peer and channel number,
+    ## we can use one timer to unlock them both
+    lock_timer_refs: %{Format.channel_number => timer_ref :: reference},
     by_peer: %{peer :: Client.address => Channel.t},
     by_number: %{Format.channel_number  => Channel.t}
   }

--- a/lib/jerboa/client/relay/channels.ex
+++ b/lib/jerboa/client/relay/channels.ex
@@ -1,0 +1,17 @@
+defmodule Jerboa.Client.Relay.Channels do
+  @moduledoc false
+
+  alias Jerboa.Client
+  alias Jerboa.Client.Relay.Channel
+  alias Jerboa.Format
+
+  defstruct locked_peers: MapSet.new(), locked_numbers: MapSet.new(),
+    by_peer: %{}, by_number: %{}
+
+  @type t :: %__MODULE__{
+    locked_peers: MapSet.t(peer :: Client.address),
+    locked_numbers: MapSet.t(Format.channel_number),
+    by_peer: %{peer :: Client.address => Channel.t},
+    by_number: %{Format.channel_number  => Channel.t}
+  }
+end

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -491,7 +491,8 @@ defmodule Jerboa.Client.Worker do
 
   @spec cancel_permission_timers(Relay.t) :: any
   defp cancel_permission_timers(relay) do
-    Relay.get_permission_timers(relay)
+    relay
+    |> Relay.get_permission_timers()
     |> Enum.each(fn timer_ref ->
       Process.cancel_timer(timer_ref)
     end)
@@ -503,8 +504,11 @@ defmodule Jerboa.Client.Worker do
       {:channel_expired, peer, channel_number}, @channel_expiry
     channel = %Channel{peer: peer, number: channel_number,
                        timer_ref: timer_ref}
-    cancel_timer = fn channel -> _ = Process.cancel_timer(channel.timer_ref) end
-    Relay.put_channel(relay, channel, cancel_timer)
+    update_channel = fn c ->
+      _ = Process.cancel_timer(c.timer_ref)
+      channel
+    end
+    Relay.put_channel(relay, channel, update_channel)
   end
 
   @spec cancel_channel_timers(Relay.t) :: any

--- a/lib/jerboa/client/worker.ex
+++ b/lib/jerboa/client/worker.ex
@@ -176,7 +176,6 @@ defmodule Jerboa.Client.Worker do
     end
     new_relay =
       state.relay
-      |> remove_permission(peer_addr)
       |> remove_channel(peer, channel_number)
     {:noreply, %{state | relay: new_relay}}
   end

--- a/lib/jerboa/format.ex
+++ b/lib/jerboa/format.ex
@@ -68,16 +68,18 @@ defmodule Jerboa.Format do
 
   @doc """
   The same as `decode/1` but raises one of various exceptions if the
-  binary doesn't encode a STUN message
+  binary doesn't encode a STUN or ChannelData message
   """
   @spec decode!(binary, options :: Keyword.t)
-    :: Params.t | {Params.t, extra :: binary} | no_return
+    :: Params.t | ChannelData.t
+    | {Params.t | ChannelData.t, extra :: binary}
+    | no_return
   def decode!(bin, options \\ []) do
     case decode(bin, options) do
-      {:ok, params} ->
-        params
-      {:ok, params, extra} ->
-        {params, extra}
+      {:ok, params_or_channel_data} ->
+        params_or_channel_data
+      {:ok, params_or_channel_data, extra} ->
+        {params_or_channel_data, extra}
       {:error, e} ->
         raise e
     end

--- a/test/jerboa/client/protocol/channel_bind_test.exs
+++ b/test/jerboa/client/protocol/channel_bind_test.exs
@@ -1,0 +1,100 @@
+defmodule Jerboa.Client.Protocol.ChannelBindTest do
+  use ExUnit.Case
+
+  alias Jerboa.Params
+  alias Jerboa.Client.Protocol
+  alias Jerboa.Client.Protocol.ChannelBind
+  alias Jerboa.Test.Helper.Params, as: PH
+  alias Jerboa.Test.Helper.Credentials, as: CH
+  alias Jerboa.Format.Body.Attribute.XORPeerAddress, as: XPA
+  alias Jerboa.Format.Body.Attribute.{ChannelNumber, Nonce, ErrorCode}
+
+  test "request/2 returns valid channel bind request signed with creds" do
+    creds = CH.final()
+    channel_number = 0x4001
+    peer_ip = {127, 0, 0, 1}
+    peer_port = 1234
+    peer = {peer_ip, peer_port}
+
+    {id, request} = ChannelBind.request(creds, peer, channel_number)
+    params = Protocol.decode!(request, creds)
+
+    assert params.identifier == id
+    assert params.class == :request
+    assert params.method == :channel_bind
+    assert params.signed?
+    assert params.verified?
+    assert PH.username(params) == creds.username
+    assert PH.realm(params) == creds.realm
+    assert PH.nonce(params) == creds.nonce
+    assert %ChannelNumber{number: channel_number} ==
+      Params.get_attr(params, ChannelNumber)
+    assert %XPA{address: ^peer_ip, port: ^peer_port, family: :ipv4} =
+      Params.get_attr(params, XPA)
+  end
+
+  describe "eval_response/2" do
+    test "returns :ok on successful channel bind response" do
+      creds = CH.final()
+
+      params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_method(:channel_bind)
+
+      assert :ok == ChannelBind.eval_response(params, creds)
+    end
+
+    test "returns :bad_response on invalid STUN method" do
+      creds = CH.final()
+
+      params =
+        Params.new()
+        |> Params.put_class(:success)
+        |> Params.put_class(:allocate)
+
+      assert {:error, :bad_response, creds} ==
+        ChannelBind.eval_response(params, creds)
+    end
+
+    test "returns :bad_response on failure without ERROR-CODE" do
+      creds = CH.final()
+
+      params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:channel_bind)
+
+      assert {:error, :bad_response, creds} ==
+        ChannelBind.eval_response(params, creds)
+    end
+
+    test "returns creds with updated nonce on :stale_nonce error" do
+      creds = CH.final() |> Map.put(:nonce, "I'm expired")
+      new_nonce = CH.valid_nonce()
+
+      params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:channel_bind)
+        |> Params.put_attr(%Nonce{value: new_nonce})
+        |> Params.put_attr(%ErrorCode{name: :stale_nonce})
+
+      assert {:error, :stale_nonce, %{creds | nonce: new_nonce}} ==
+        ChannelBind.eval_response(params, creds)
+    end
+
+    test "returns unchanged creds and error name on other errors" do
+      creds = CH.final()
+      error = :forbidden
+
+      params =
+        Params.new()
+        |> Params.put_class(:failure)
+        |> Params.put_method(:channel_bind)
+        |> Params.put_attr(%ErrorCode{name: error})
+
+      assert {:error, error, creds} == ChannelBind.eval_response(params, creds)
+    end
+  end
+end

--- a/test/jerboa/client/protocol_test.exs
+++ b/test/jerboa/client/protocol_test.exs
@@ -1,7 +1,7 @@
 defmodule Jerboa.Client.ProtocolTest do
   use ExUnit.Case
 
-  alias Jerboa.{Params, Format}
+  alias Jerboa.{Params, Format, ChannelData}
   alias Jerboa.Client.Protocol
   alias Jerboa.Format.Body.Attribute.{Nonce, ErrorCode}
   alias Jerboa.Test.Helper.Params, as: PH
@@ -111,5 +111,15 @@ defmodule Jerboa.Client.ProtocolTest do
       assert {:error, error, creds} ==
         Protocol.eval_failure(params, creds)
     end
+  end
+
+  test "encode_channel_data/2 encodes a channel data message" do
+    channel_number = 0x4001
+    data = "alicehasacat"
+
+    encoded = Protocol.encode_channel_data(channel_number, data)
+
+    assert {:ok, %ChannelData{channel_number: channel_number, data: data}} ==
+      Format.decode(encoded)
   end
 end

--- a/test/jerboa/client/relay_test.exs
+++ b/test/jerboa/client/relay_test.exs
@@ -1,0 +1,234 @@
+defmodule Jerboa.Client.RelayTest do
+  use ExUnit.Case
+
+  @moduletag :now
+
+  alias Jerboa.Client.Relay
+  alias Jerboa.Client.Relay.Channel
+
+  describe "active?/1" do
+    test "returns true if relayed address is not nil" do
+      relay = %Relay{address: {{127, 0, 0, 1}, 12_345}}
+
+      assert Relay.active?(relay)
+    end
+
+    test "returns false if relayed address is nil" do
+      relay = %Relay{address: nil}
+
+      refute Relay.active?(relay)
+    end
+  end
+
+  test "put_address/2 sets relay address" do
+    address = {{127, 0, 0, 1}, 12_345}
+
+    relay = %Relay{} |> Relay.put_address(address)
+
+    assert relay.address == address
+  end
+
+  test "put_lifetime/2 sets relay lifetime" do
+    lifetime = 600
+
+    relay = %Relay{} |> Relay.put_lifetime(lifetime)
+
+    assert relay.lifetime == lifetime
+  end
+
+  test "put_timer_ref/2 sets relay expiration timer reference" do
+    timer_ref = make_ref()
+
+    relay = %Relay{} |> Relay.put_timer_ref(timer_ref)
+
+    assert relay.timer_ref == timer_ref
+  end
+
+  test "put_permissions/2 sets relay permissions" do
+    permissions = %{{127, 0, 0, 1} => make_ref()}
+
+    relay = %Relay{} |> Relay.put_permissions(permissions)
+
+    assert relay.permissions == permissions
+  end
+
+  test "remove_permissions/2 deletes permission for given peer IP" do
+    addr1 = {127, 0, 0, 1}
+    addr2 = {172, 16, 0, 1}
+    permissions = %{addr1 => make_ref(), addr2 => make_ref()}
+
+    relay =
+      %Relay{}
+      |> Relay.put_permissions(permissions)
+      |> Relay.remove_permission(addr1)
+    permission_ips = Map.keys(relay.permissions)
+
+    refute addr1 in permission_ips
+    assert addr2 in permission_ips
+  end
+
+  test "has_permission?/2 check wheter there is permission for given peer" do
+    addr1 = {127, 0, 0, 1}
+    peer1 = {addr1, 12_345}
+    addr2 = {172, 16, 0, 1}
+    peer2 = {addr2, 12_345}
+    permissions = %{addr1 => make_ref()}
+
+    relay = %Relay{} |> Relay.put_permissions(permissions)
+
+    assert Relay.has_permission?(relay, peer1)
+    refute Relay.has_permission?(relay, peer2)
+  end
+
+  test "get_permission_timers/1 returns list of permission timers refs" do
+    timer_ref1 = make_ref()
+    timer_ref2 = make_ref()
+    permissions = %{{127, 0, 0, 1} => timer_ref1}
+
+    relay = %Relay{} |> Relay.put_permissions(permissions)
+    timer_refs = Relay.get_permission_timers(relay)
+
+    assert length(timer_refs) == 1
+    assert timer_ref1 in timer_refs
+    refute timer_ref2 in timer_refs
+  end
+
+  test "put_channel/2 adds a new channel if it wasn't present before" do
+    peer = {{127, 0, 0, 1}, 12_345}
+    channel_number = 0x4000
+    channel = %Channel{peer: peer, number: channel_number,
+                       timer_ref: make_ref()}
+
+    relay = %Relay{} |> Relay.put_channel(channel)
+
+    assert {:ok, channel} == Relay.get_channel_by_number(relay, channel_number)
+    assert {:ok, channel} == Relay.get_channel_by_peer(relay, peer)
+  end
+
+  test "put_channel/3 maps channel with a given functon it is " <>
+    "already present" do
+    peer = {{127, 0, 0, 1}, 12_345}
+    channel_number = 0x4000
+    channel = %Channel{peer: peer, number: channel_number,
+                       timer_ref: make_ref()}
+    new_timer_ref = make_ref()
+
+    relay =
+      %Relay{}
+      |> Relay.put_channel(channel)
+      |> Relay.put_channel(channel, fn c -> %{c | timer_ref: new_timer_ref} end)
+
+    updated_channel = %{channel | timer_ref: new_timer_ref}
+    assert {:ok, updated_channel} ==
+      Relay.get_channel_by_number(relay, channel_number)
+    assert {:ok, updated_channel} == Relay.get_channel_by_peer(relay, peer)
+  end
+
+  test "remove_channel/3 deletes the channel from the relay" do
+    peer = {{127, 0, 0, 1}, 12_345}
+    channel_number = 0x4000
+    channel = %Channel{peer: peer, number: channel_number,
+                       timer_ref: make_ref()}
+    relay =
+      %Relay{}
+      |> Relay.put_channel(channel)
+      |> Relay.remove_channel(peer, channel_number)
+
+    refute channel in Relay.get_channels(relay)
+    assert :error == Relay.get_channel_by_number(relay, channel_number)
+    assert :error == Relay.get_channel_by_peer(relay, peer)
+  end
+
+  test "get_channels/1 returns a list of all channels" do
+    channel1 = %Channel{peer: {{127, 0, 0, 1}, 12_345}, number: 0x4000,
+                        timer_ref: make_ref()}
+    channel2 = %Channel{peer: {{172, 16, 0, 1}, 12_345}, number: 0x4001,
+                        timer_ref: make_ref()}
+
+    relay = %Relay{} |> Relay.put_channel(channel1)
+    channels = Relay.get_channels(relay)
+
+    assert length(channels) == 1
+    assert channel1 in channels
+    refute channel2 in channels
+  end
+
+  test "has_channel_bound?/2 returns true if there is channel for the " <>
+    "given peer" do
+    peer1 = {{127, 0, 0, 1}, 12_345}
+    peer2 = {{172, 16, 0, 1}, 12_345}
+    channel = %Channel{peer: peer1, number: 0x4000, timer_ref: make_ref()}
+
+    relay = %Relay{} |> Relay.put_channel(channel)
+
+    assert Relay.has_channel_bound?(relay, peer1)
+    refute Relay.has_channel_bound?(relay, peer2)
+  end
+
+  describe "gen_channel_number/2" do
+    test "returns :peer_locked if the peer is locked" do
+      peer = {{127, 0, 0, 1}, 12_345}
+      channel_number = 0x4000
+
+      relay = %Relay{} |> Relay.lock_channel(peer, channel_number)
+
+      assert {:error, :peer_locked} == Relay.gen_channel_number(relay, peer)
+    end
+
+    test "returns :capacity_reached if there are no more free channel numbers" do
+      locked_range = 0x4000..0x5FFF
+      taken_range = 0x6000..0x7FFF
+      gen_peer = fn channel_number -> {{127, 0, 0, 1}, channel_number} end
+      relay1 = Enum.reduce(locked_range, %Relay{}, fn number, relay ->
+        Relay.lock_channel(relay, gen_peer.(number), number)
+      end)
+      relay2 = Enum.reduce(taken_range, relay1, fn number, relay ->
+        channel = %Channel{number: number, peer: gen_peer.(number),
+                          timer_ref: make_ref()}
+        Relay.put_channel(relay, channel)
+      end)
+
+      assert {:error, :capacity_reached} == Relay.gen_channel_number(relay2,
+        gen_peer.(12_345))
+    end
+
+    test "returns channel number if the peer has channel bound" do
+      peer = {{127, 0, 0, 1}, 12_345}
+      channel_number = 0x4000
+      channel = %Channel{peer: peer, number: channel_number, timer_ref: make_ref}
+      relay = %Relay{} |> Relay.put_channel(channel)
+
+      assert {:ok, channel_number} == Relay.gen_channel_number(relay, peer)
+    end
+
+    test "returns new channel number if the peer does not have channel bound" do
+      peer = {{127, 0, 0, 1}, 12_345}
+      relay = %Relay{}
+
+      assert {:ok, _} = Relay.gen_channel_number(relay, peer)
+    end
+  end
+
+  test "lock and unlock channel" do
+    peer = {{127, 0, 0, 1}, 12_345}
+    channel_number = 0x4000
+
+    relay1 = %Relay{} |> Relay.lock_channel(peer, channel_number)
+    assert {:error, :peer_locked} = Relay.gen_channel_number(relay1, peer)
+
+    relay2 = Relay.unlock_channel(relay1, peer, channel_number)
+    assert {:ok, _} = Relay.gen_channel_number(relay2, peer)
+  end
+
+  test "add and remove lock timer reference" do
+    timer_ref = make_ref()
+    channel_number = 0x4000
+
+    relay1 = %Relay{} |> Relay.put_lock_timer_ref(channel_number, timer_ref)
+    assert timer_ref in Relay.get_lock_timer_refs(relay1)
+
+    relay2 = %Relay{} |> Relay.remove_lock_timer_ref(channel_number)
+    refute timer_ref in Relay.get_lock_timer_refs(relay2)
+  end
+
+end


### PR DESCRIPTION
This PR implements channels mechanism for TURN client:
`Client.open_channel/2` issues a ChannelBind request to the server. After successful response channel is bound to the given peer and all data sent to the peer (using `Client.send/3`) uses `ChannelData` messages instead of default Data indications.

Closes #78 
Closes #79

There are a lot of commits here, because this PR also includes changes from #115. #115 should be merged first.