### PR TITLE
Increment OTP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ after_script:
 elixir:
   - 1.4.0
 otp_release:
-  - 19.2
+  - 19.3
   - 18.3
 env:
   - PRESET=test
 
 matrix:
   include:
-    - otp_release: 19.2
+    - otp_release: 19.3
       elixir: 1.4.0
       env: PRESET=dialyzer
 


### PR DESCRIPTION
Travis does not provide OTP 19.2 any more which made the CI fail.
This is just a quick check to see if this should fix the problem, but we should anyway update to even higher versions.